### PR TITLE
Issue #3: Permission Actions & Subjects

### DIFF
--- a/app/Enums/PermissionAction.php
+++ b/app/Enums/PermissionAction.php
@@ -1,0 +1,92 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Enums;
+
+/**
+ * Permission actions that can be performed on subjects.
+ */
+enum PermissionAction: string
+{
+    case View = 'view';
+    case Create = 'create';
+    case Edit = 'edit';
+    case Delete = 'delete';
+    case Manage = 'manage';
+    case Close = 'close';
+    case Assign = 'assign';
+
+    /**
+     * Get the display label for the action.
+     */
+    public function label(): string
+    {
+        return match ($this) {
+            self::View => 'View',
+            self::Create => 'Create',
+            self::Edit => 'Edit',
+            self::Delete => 'Delete',
+            self::Manage => 'Manage',
+            self::Close => 'Close',
+            self::Assign => 'Assign',
+        };
+    }
+
+    /**
+     * Get the Arabic label for the action.
+     */
+    public function labelAr(): string
+    {
+        return match ($this) {
+            self::View => 'عرض',
+            self::Create => 'إنشاء',
+            self::Edit => 'تعديل',
+            self::Delete => 'حذف',
+            self::Manage => 'إدارة',
+            self::Close => 'إغلاق',
+            self::Assign => 'تعيين',
+        };
+    }
+
+    /**
+     * Check if this is a destructive action.
+     */
+    public function isDestructive(): bool
+    {
+        return $this === self::Delete;
+    }
+
+    /**
+     * Check if this is a read-only action.
+     */
+    public function isReadOnly(): bool
+    {
+        return $this === self::View;
+    }
+
+    /**
+     * Get all CRUD actions.
+     *
+     * @return array<self>
+     */
+    public static function crud(): array
+    {
+        return [
+            self::View,
+            self::Create,
+            self::Edit,
+            self::Delete,
+        ];
+    }
+
+    /**
+     * Get all values as an array.
+     *
+     * @return array<string>
+     */
+    public static function values(): array
+    {
+        return array_column(self::cases(), 'value');
+    }
+}

--- a/app/Enums/PermissionSubject.php
+++ b/app/Enums/PermissionSubject.php
@@ -1,0 +1,258 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Enums;
+
+/**
+ * Permission subjects that actions can be performed on.
+ *
+ * Based on the 23 identified subjects in the Atar system.
+ */
+enum PermissionSubject: string
+{
+    // Properties
+    case Communities = 'communities';
+    case Buildings = 'buildings';
+    case Units = 'units';
+    case Facilities = 'facilities';
+
+    // Contacts
+    case Owners = 'owners';
+    case Tenants = 'tenants';
+    case Admins = 'admins';
+    case Professionals = 'professionals';
+
+    // Leasing
+    case Leases = 'leases';
+    case SubLeases = 'sub-leases';
+    case Quotes = 'quotes';
+    case Applications = 'applications';
+
+    // Transactions
+    case Transactions = 'transactions';
+    case Invoices = 'invoices';
+    case Payments = 'payments';
+    case FinancialReports = 'financial-reports';
+
+    // Service Requests
+    case ServiceRequests = 'service-requests';
+    case ServiceCategories = 'service-categories';
+
+    // Operations
+    case VisitorAccess = 'visitor-access';
+    case FacilityBookings = 'facility-bookings';
+
+    // Marketplace
+    case Marketplace = 'marketplace';
+    case MarketplaceListings = 'marketplace-listings';
+
+    // Settings & Communication
+    case Settings = 'settings';
+    case Announcements = 'announcements';
+    case Notifications = 'notifications';
+    case Reports = 'reports';
+    case Users = 'users';
+
+    /**
+     * Get the display label for the subject.
+     */
+    public function label(): string
+    {
+        return match ($this) {
+            self::Communities => 'Communities',
+            self::Buildings => 'Buildings',
+            self::Units => 'Units',
+            self::Facilities => 'Facilities',
+            self::Owners => 'Owners',
+            self::Tenants => 'Tenants',
+            self::Admins => 'Admins',
+            self::Professionals => 'Professionals',
+            self::Leases => 'Leases',
+            self::SubLeases => 'Sub-leases',
+            self::Quotes => 'Quotes',
+            self::Applications => 'Applications',
+            self::Transactions => 'Transactions',
+            self::Invoices => 'Invoices',
+            self::Payments => 'Payments',
+            self::FinancialReports => 'Financial Reports',
+            self::ServiceRequests => 'Service Requests',
+            self::ServiceCategories => 'Service Categories',
+            self::VisitorAccess => 'Visitor Access',
+            self::FacilityBookings => 'Facility Bookings',
+            self::Marketplace => 'Marketplace',
+            self::MarketplaceListings => 'Marketplace Listings',
+            self::Settings => 'Settings',
+            self::Announcements => 'Announcements',
+            self::Notifications => 'Notifications',
+            self::Reports => 'Reports',
+            self::Users => 'Users',
+        };
+    }
+
+    /**
+     * Get the module this subject belongs to.
+     */
+    public function module(): string
+    {
+        return match ($this) {
+            self::Communities,
+            self::Buildings,
+            self::Units,
+            self::Facilities => 'properties',
+
+            self::Owners,
+            self::Tenants,
+            self::Admins,
+            self::Professionals => 'contacts',
+
+            self::Leases,
+            self::SubLeases,
+            self::Quotes,
+            self::Applications => 'leasing',
+
+            self::Transactions,
+            self::Invoices,
+            self::Payments,
+            self::FinancialReports => 'transactions',
+
+            self::ServiceRequests,
+            self::ServiceCategories => 'service-requests',
+
+            self::VisitorAccess,
+            self::FacilityBookings => 'operations',
+
+            self::Marketplace,
+            self::MarketplaceListings => 'marketplace',
+
+            self::Settings,
+            self::Announcements,
+            self::Notifications,
+            self::Reports,
+            self::Users => 'settings',
+        };
+    }
+
+    /**
+     * Get the applicable actions for this subject.
+     *
+     * @return array<PermissionAction>
+     */
+    public function applicableActions(): array
+    {
+        return match ($this) {
+            // Most subjects support full CRUD + manage
+            self::Communities,
+            self::Buildings,
+            self::Units,
+            self::Facilities,
+            self::Owners,
+            self::Tenants,
+            self::Admins,
+            self::Professionals,
+            self::Leases,
+            self::SubLeases,
+            self::Transactions,
+            self::MarketplaceListings,
+            self::Announcements,
+            self::Users => [
+                PermissionAction::View,
+                PermissionAction::Create,
+                PermissionAction::Edit,
+                PermissionAction::Delete,
+                PermissionAction::Manage,
+            ],
+
+            // Service requests have additional actions
+            self::ServiceRequests => [
+                PermissionAction::View,
+                PermissionAction::Create,
+                PermissionAction::Edit,
+                PermissionAction::Delete,
+                PermissionAction::Manage,
+                PermissionAction::Close,
+                PermissionAction::Assign,
+            ],
+
+            // Read-only subjects
+            self::FinancialReports,
+            self::Reports => [
+                PermissionAction::View,
+            ],
+
+            // Settings and system
+            self::Settings,
+            self::Notifications => [
+                PermissionAction::View,
+                PermissionAction::Edit,
+                PermissionAction::Manage,
+            ],
+
+            // Other subjects
+            default => [
+                PermissionAction::View,
+                PermissionAction::Create,
+                PermissionAction::Edit,
+                PermissionAction::Delete,
+                PermissionAction::Manage,
+            ],
+        };
+    }
+
+    /**
+     * Generate permission string for an action on this subject.
+     */
+    public function permissionFor(PermissionAction $action): string
+    {
+        return "{$action->value}-{$this->value}";
+    }
+
+    /**
+     * Get all permissions for this subject.
+     *
+     * @return array<string>
+     */
+    public function allPermissions(): array
+    {
+        return array_map(
+            fn (PermissionAction $action) => $this->permissionFor($action),
+            $this->applicableActions()
+        );
+    }
+
+    /**
+     * Get subjects by module.
+     *
+     * @return array<self>
+     */
+    public static function byModule(string $module): array
+    {
+        return array_values(array_filter(
+            self::cases(),
+            fn (self $subject) => $subject->module() === $module
+        ));
+    }
+
+    /**
+     * Get all available modules.
+     *
+     * @return array<string>
+     */
+    public static function modules(): array
+    {
+        return array_unique(array_map(
+            fn (self $subject) => $subject->module(),
+            self::cases()
+        ));
+    }
+
+    /**
+     * Get all values as an array.
+     *
+     * @return array<string>
+     */
+    public static function values(): array
+    {
+        return array_column(self::cases(), 'value');
+    }
+}

--- a/tests/Feature/PermissionActionsSubjectsTest.php
+++ b/tests/Feature/PermissionActionsSubjectsTest.php
@@ -1,0 +1,322 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Enums\PermissionAction;
+use App\Enums\PermissionSubject;
+use Tests\TestCase;
+
+class PermissionActionsSubjectsTest extends TestCase
+{
+    public function test_permission_action_has_all_expected_values(): void
+    {
+        $actions = PermissionAction::cases();
+
+        $this->assertCount(7, $actions);
+        $this->assertContains(PermissionAction::View, $actions);
+        $this->assertContains(PermissionAction::Create, $actions);
+        $this->assertContains(PermissionAction::Edit, $actions);
+        $this->assertContains(PermissionAction::Delete, $actions);
+        $this->assertContains(PermissionAction::Manage, $actions);
+        $this->assertContains(PermissionAction::Close, $actions);
+        $this->assertContains(PermissionAction::Assign, $actions);
+    }
+
+    public function test_permission_action_labels(): void
+    {
+        $this->assertEquals('View', PermissionAction::View->label());
+        $this->assertEquals('Create', PermissionAction::Create->label());
+        $this->assertEquals('Edit', PermissionAction::Edit->label());
+        $this->assertEquals('Delete', PermissionAction::Delete->label());
+        $this->assertEquals('Manage', PermissionAction::Manage->label());
+        $this->assertEquals('Close', PermissionAction::Close->label());
+        $this->assertEquals('Assign', PermissionAction::Assign->label());
+    }
+
+    public function test_permission_action_arabic_labels(): void
+    {
+        $this->assertEquals('عرض', PermissionAction::View->labelAr());
+        $this->assertEquals('إنشاء', PermissionAction::Create->labelAr());
+        $this->assertEquals('تعديل', PermissionAction::Edit->labelAr());
+        $this->assertEquals('حذف', PermissionAction::Delete->labelAr());
+        $this->assertEquals('إدارة', PermissionAction::Manage->labelAr());
+        $this->assertEquals('إغلاق', PermissionAction::Close->labelAr());
+        $this->assertEquals('تعيين', PermissionAction::Assign->labelAr());
+    }
+
+    public function test_permission_action_destructive_check(): void
+    {
+        $this->assertTrue(PermissionAction::Delete->isDestructive());
+        $this->assertFalse(PermissionAction::View->isDestructive());
+        $this->assertFalse(PermissionAction::Create->isDestructive());
+        $this->assertFalse(PermissionAction::Edit->isDestructive());
+        $this->assertFalse(PermissionAction::Manage->isDestructive());
+    }
+
+    public function test_permission_action_readonly_check(): void
+    {
+        $this->assertTrue(PermissionAction::View->isReadOnly());
+        $this->assertFalse(PermissionAction::Create->isReadOnly());
+        $this->assertFalse(PermissionAction::Edit->isReadOnly());
+        $this->assertFalse(PermissionAction::Delete->isReadOnly());
+        $this->assertFalse(PermissionAction::Manage->isReadOnly());
+    }
+
+    public function test_permission_action_crud_returns_four_actions(): void
+    {
+        $crud = PermissionAction::crud();
+
+        $this->assertCount(4, $crud);
+        $this->assertContains(PermissionAction::View, $crud);
+        $this->assertContains(PermissionAction::Create, $crud);
+        $this->assertContains(PermissionAction::Edit, $crud);
+        $this->assertContains(PermissionAction::Delete, $crud);
+        $this->assertNotContains(PermissionAction::Manage, $crud);
+    }
+
+    public function test_permission_action_values(): void
+    {
+        $values = PermissionAction::values();
+
+        $this->assertContains('view', $values);
+        $this->assertContains('create', $values);
+        $this->assertContains('edit', $values);
+        $this->assertContains('delete', $values);
+        $this->assertContains('manage', $values);
+        $this->assertContains('close', $values);
+        $this->assertContains('assign', $values);
+    }
+
+    public function test_permission_subject_has_all_expected_values(): void
+    {
+        $subjects = PermissionSubject::cases();
+
+        $this->assertCount(27, $subjects);
+    }
+
+    public function test_permission_subject_properties_module(): void
+    {
+        $this->assertEquals('properties', PermissionSubject::Communities->module());
+        $this->assertEquals('properties', PermissionSubject::Buildings->module());
+        $this->assertEquals('properties', PermissionSubject::Units->module());
+        $this->assertEquals('properties', PermissionSubject::Facilities->module());
+    }
+
+    public function test_permission_subject_contacts_module(): void
+    {
+        $this->assertEquals('contacts', PermissionSubject::Owners->module());
+        $this->assertEquals('contacts', PermissionSubject::Tenants->module());
+        $this->assertEquals('contacts', PermissionSubject::Admins->module());
+        $this->assertEquals('contacts', PermissionSubject::Professionals->module());
+    }
+
+    public function test_permission_subject_leasing_module(): void
+    {
+        $this->assertEquals('leasing', PermissionSubject::Leases->module());
+        $this->assertEquals('leasing', PermissionSubject::SubLeases->module());
+        $this->assertEquals('leasing', PermissionSubject::Quotes->module());
+        $this->assertEquals('leasing', PermissionSubject::Applications->module());
+    }
+
+    public function test_permission_subject_transactions_module(): void
+    {
+        $this->assertEquals('transactions', PermissionSubject::Transactions->module());
+        $this->assertEquals('transactions', PermissionSubject::Invoices->module());
+        $this->assertEquals('transactions', PermissionSubject::Payments->module());
+        $this->assertEquals('transactions', PermissionSubject::FinancialReports->module());
+    }
+
+    public function test_permission_subject_service_requests_module(): void
+    {
+        $this->assertEquals('service-requests', PermissionSubject::ServiceRequests->module());
+        $this->assertEquals('service-requests', PermissionSubject::ServiceCategories->module());
+    }
+
+    public function test_permission_subject_operations_module(): void
+    {
+        $this->assertEquals('operations', PermissionSubject::VisitorAccess->module());
+        $this->assertEquals('operations', PermissionSubject::FacilityBookings->module());
+    }
+
+    public function test_permission_subject_marketplace_module(): void
+    {
+        $this->assertEquals('marketplace', PermissionSubject::Marketplace->module());
+        $this->assertEquals('marketplace', PermissionSubject::MarketplaceListings->module());
+    }
+
+    public function test_permission_subject_settings_module(): void
+    {
+        $this->assertEquals('settings', PermissionSubject::Settings->module());
+        $this->assertEquals('settings', PermissionSubject::Announcements->module());
+        $this->assertEquals('settings', PermissionSubject::Notifications->module());
+        $this->assertEquals('settings', PermissionSubject::Reports->module());
+        $this->assertEquals('settings', PermissionSubject::Users->module());
+    }
+
+    public function test_permission_subject_labels(): void
+    {
+        $this->assertEquals('Communities', PermissionSubject::Communities->label());
+        $this->assertEquals('Buildings', PermissionSubject::Buildings->label());
+        $this->assertEquals('Sub-leases', PermissionSubject::SubLeases->label());
+        $this->assertEquals('Service Requests', PermissionSubject::ServiceRequests->label());
+        $this->assertEquals('Financial Reports', PermissionSubject::FinancialReports->label());
+    }
+
+    public function test_permission_subject_applicable_actions_for_crud_subjects(): void
+    {
+        $communityActions = PermissionSubject::Communities->applicableActions();
+
+        $this->assertContains(PermissionAction::View, $communityActions);
+        $this->assertContains(PermissionAction::Create, $communityActions);
+        $this->assertContains(PermissionAction::Edit, $communityActions);
+        $this->assertContains(PermissionAction::Delete, $communityActions);
+        $this->assertContains(PermissionAction::Manage, $communityActions);
+    }
+
+    public function test_permission_subject_service_requests_has_additional_actions(): void
+    {
+        $serviceRequestActions = PermissionSubject::ServiceRequests->applicableActions();
+
+        $this->assertContains(PermissionAction::View, $serviceRequestActions);
+        $this->assertContains(PermissionAction::Create, $serviceRequestActions);
+        $this->assertContains(PermissionAction::Edit, $serviceRequestActions);
+        $this->assertContains(PermissionAction::Delete, $serviceRequestActions);
+        $this->assertContains(PermissionAction::Manage, $serviceRequestActions);
+        $this->assertContains(PermissionAction::Close, $serviceRequestActions);
+        $this->assertContains(PermissionAction::Assign, $serviceRequestActions);
+    }
+
+    public function test_permission_subject_readonly_subjects(): void
+    {
+        $reportActions = PermissionSubject::FinancialReports->applicableActions();
+
+        $this->assertContains(PermissionAction::View, $reportActions);
+        $this->assertNotContains(PermissionAction::Create, $reportActions);
+        $this->assertNotContains(PermissionAction::Edit, $reportActions);
+        $this->assertNotContains(PermissionAction::Delete, $reportActions);
+    }
+
+    public function test_permission_subject_settings_actions(): void
+    {
+        $settingsActions = PermissionSubject::Settings->applicableActions();
+
+        $this->assertContains(PermissionAction::View, $settingsActions);
+        $this->assertContains(PermissionAction::Edit, $settingsActions);
+        $this->assertContains(PermissionAction::Manage, $settingsActions);
+        $this->assertNotContains(PermissionAction::Create, $settingsActions);
+        $this->assertNotContains(PermissionAction::Delete, $settingsActions);
+    }
+
+    public function test_permission_for_generates_correct_string(): void
+    {
+        $this->assertEquals(
+            'view-communities',
+            PermissionSubject::Communities->permissionFor(PermissionAction::View)
+        );
+        $this->assertEquals(
+            'create-buildings',
+            PermissionSubject::Buildings->permissionFor(PermissionAction::Create)
+        );
+        $this->assertEquals(
+            'edit-leases',
+            PermissionSubject::Leases->permissionFor(PermissionAction::Edit)
+        );
+        $this->assertEquals(
+            'delete-transactions',
+            PermissionSubject::Transactions->permissionFor(PermissionAction::Delete)
+        );
+        $this->assertEquals(
+            'manage-users',
+            PermissionSubject::Users->permissionFor(PermissionAction::Manage)
+        );
+    }
+
+    public function test_all_permissions_for_subject(): void
+    {
+        $communityPermissions = PermissionSubject::Communities->allPermissions();
+
+        $this->assertContains('view-communities', $communityPermissions);
+        $this->assertContains('create-communities', $communityPermissions);
+        $this->assertContains('edit-communities', $communityPermissions);
+        $this->assertContains('delete-communities', $communityPermissions);
+        $this->assertContains('manage-communities', $communityPermissions);
+    }
+
+    public function test_by_module_returns_correct_subjects(): void
+    {
+        $propertySubjects = PermissionSubject::byModule('properties');
+
+        $this->assertContains(PermissionSubject::Communities, $propertySubjects);
+        $this->assertContains(PermissionSubject::Buildings, $propertySubjects);
+        $this->assertContains(PermissionSubject::Units, $propertySubjects);
+        $this->assertContains(PermissionSubject::Facilities, $propertySubjects);
+        $this->assertNotContains(PermissionSubject::Leases, $propertySubjects);
+    }
+
+    public function test_modules_returns_unique_list(): void
+    {
+        $modules = PermissionSubject::modules();
+
+        $this->assertContains('properties', $modules);
+        $this->assertContains('contacts', $modules);
+        $this->assertContains('leasing', $modules);
+        $this->assertContains('transactions', $modules);
+        $this->assertContains('service-requests', $modules);
+        $this->assertContains('operations', $modules);
+        $this->assertContains('marketplace', $modules);
+        $this->assertContains('settings', $modules);
+    }
+
+    public function test_permission_subject_values(): void
+    {
+        $values = PermissionSubject::values();
+
+        $this->assertContains('communities', $values);
+        $this->assertContains('buildings', $values);
+        $this->assertContains('units', $values);
+        $this->assertContains('leases', $values);
+        $this->assertContains('sub-leases', $values);
+        $this->assertContains('service-requests', $values);
+    }
+
+    public function test_permission_generation_consistency(): void
+    {
+        // Verify that all subjects generate valid permissions
+        foreach (PermissionSubject::cases() as $subject) {
+            $permissions = $subject->allPermissions();
+
+            $this->assertIsArray($permissions);
+            $this->assertNotEmpty($permissions);
+
+            foreach ($permissions as $permission) {
+                $this->assertIsString($permission);
+                $this->assertStringContainsString('-', $permission);
+                $this->assertStringContainsString($subject->value, $permission);
+            }
+        }
+    }
+
+    public function test_module_grouping_is_complete(): void
+    {
+        // Every subject should belong to a module
+        foreach (PermissionSubject::cases() as $subject) {
+            $module = $subject->module();
+            $this->assertIsString($module);
+            $this->assertNotEmpty($module);
+        }
+    }
+
+    public function test_applicable_actions_are_valid(): void
+    {
+        // Every subject should have applicable actions
+        foreach (PermissionSubject::cases() as $subject) {
+            $actions = $subject->applicableActions();
+            $this->assertIsArray($actions);
+            $this->assertNotEmpty($actions);
+
+            foreach ($actions as $action) {
+                $this->assertInstanceOf(PermissionAction::class, $action);
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Implements the Permission Actions and Subjects enums that form the foundation of the granular permission system.

### PermissionAction Enum
- 7 actions: `view`, `create`, `edit`, `delete`, `manage`, `close`, `assign`
- Helper methods: `label()`, `labelAr()`, `isDestructive()`, `isReadOnly()`, `crud()`
- Static methods: `values()`

### PermissionSubject Enum
- 27 subjects organized by module:
  - **Properties**: Communities, Buildings, Units, Facilities
  - **Contacts**: Owners, Tenants, Admins, Professionals
  - **Leasing**: Leases, SubLeases, Quotes, Applications
  - **Transactions**: Transactions, Invoices, Payments, FinancialReports
  - **Service Requests**: ServiceRequests, ServiceCategories
  - **Operations**: VisitorAccess, FacilityBookings
  - **Marketplace**: Marketplace, MarketplaceListings
  - **Settings**: Settings, Announcements, Notifications, Reports, Users

- Methods: `label()`, `module()`, `applicableActions()`, `permissionFor()`, `allPermissions()`
- Static methods: `byModule()`, `modules()`, `values()`

## Test Plan

- [x] PermissionAction enum has all 7 expected values
- [x] PermissionAction labels in English and Arabic
- [x] PermissionAction destructive/readonly checks
- [x] PermissionAction CRUD subset returns correct actions
- [x] PermissionSubject has all 27 subjects
- [x] All subjects correctly mapped to modules
- [x] Subject labels are correct
- [x] CRUD subjects have full action set
- [x] Service requests have additional close/assign actions
- [x] Read-only subjects only have view action
- [x] Settings subjects have limited actions
- [x] Permission string generation works correctly
- [x] allPermissions() returns correct permissions
- [x] byModule() filters correctly
- [x] modules() returns unique list
- [x] All 29 tests passing

Closes #3

🤖 Generated with [Claude Code](https://claude.com/claude-code)