### PR TITLE
Issue #9: Feature Flags System

### DIFF
--- a/app/Models/FeatureFlag.php
+++ b/app/Models/FeatureFlag.php
@@ -1,0 +1,151 @@
+<?php
+
+namespace App\Models;
+
+use Database\Factories\FeatureFlagFactory;
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsToMany;
+
+class FeatureFlag extends Model
+{
+    /** @use HasFactory<FeatureFlagFactory> */
+    use HasFactory;
+
+    // Category constants
+    public const CATEGORY_CONTACTS = 'contacts';
+
+    public const CATEGORY_PROPERTIES = 'properties';
+
+    public const CATEGORY_LEASING = 'leasing';
+
+    public const CATEGORY_TRANSACTIONS = 'transactions';
+
+    public const CATEGORY_REQUESTS = 'requests';
+
+    public const CATEGORY_COMMUNICATION = 'communication';
+
+    public const CATEGORY_REPORTS = 'reports';
+
+    public const CATEGORY_TOOLS = 'tools';
+
+    public const CATEGORY_INTEGRATIONS = 'integrations';
+
+    public const CATEGORY_MARKETPLACE = 'marketplace';
+
+    /**
+     * The attributes that are mass assignable.
+     *
+     * @var list<string>
+     */
+    protected $fillable = [
+        'key',
+        'name',
+        'name_ar',
+        'description',
+        'category',
+        'default_value',
+        'is_active',
+    ];
+
+    /**
+     * Get the attributes that should be cast.
+     *
+     * @return array<string, string>
+     */
+    protected function casts(): array
+    {
+        return [
+            'default_value' => 'boolean',
+            'is_active' => 'boolean',
+        ];
+    }
+
+    /**
+     * Get tenants that have this feature flag configured.
+     */
+    public function tenants(): BelongsToMany
+    {
+        return $this->belongsToMany(Tenant::class, 'tenant_feature_flags')
+            ->withPivot('is_enabled')
+            ->withTimestamps();
+    }
+
+    /**
+     * Scope to filter active feature flags.
+     */
+    public function scopeActive(Builder $query): Builder
+    {
+        return $query->where('is_active', true);
+    }
+
+    /**
+     * Scope to filter by category.
+     */
+    public function scopeForCategory(Builder $query, string $category): Builder
+    {
+        return $query->where('category', $category);
+    }
+
+    /**
+     * Scope to filter enabled by default.
+     */
+    public function scopeEnabledByDefault(Builder $query): Builder
+    {
+        return $query->where('default_value', true);
+    }
+
+    /**
+     * Find feature flag by key.
+     */
+    public static function findByKey(string $key): ?self
+    {
+        return static::where('key', $key)->first();
+    }
+
+    /**
+     * Check if feature is enabled for a tenant.
+     */
+    public function isEnabledForTenant(?Tenant $tenant): bool
+    {
+        if (! $this->is_active) {
+            return false;
+        }
+
+        if (! $tenant) {
+            return $this->default_value;
+        }
+
+        $tenantFlag = $this->tenants()
+            ->where('tenant_id', $tenant->id)
+            ->first();
+
+        if ($tenantFlag) {
+            return $tenantFlag->pivot->is_enabled;
+        }
+
+        return $this->default_value;
+    }
+
+    /**
+     * Get all available categories.
+     *
+     * @return array<string>
+     */
+    public static function categories(): array
+    {
+        return [
+            self::CATEGORY_CONTACTS,
+            self::CATEGORY_PROPERTIES,
+            self::CATEGORY_LEASING,
+            self::CATEGORY_TRANSACTIONS,
+            self::CATEGORY_REQUESTS,
+            self::CATEGORY_COMMUNICATION,
+            self::CATEGORY_REPORTS,
+            self::CATEGORY_TOOLS,
+            self::CATEGORY_INTEGRATIONS,
+            self::CATEGORY_MARKETPLACE,
+        ];
+    }
+}

--- a/app/Models/Tenant.php
+++ b/app/Models/Tenant.php
@@ -7,6 +7,7 @@ namespace App\Models;
 use Illuminate\Database\Eloquent\Attributes\Fillable;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsToMany;
 use Illuminate\Database\Eloquent\Relations\HasMany;
 use Illuminate\Database\Eloquent\SoftDeletes;
 use Illuminate\Support\Str;
@@ -93,5 +94,65 @@ class Tenant extends Model
     public function getRouteKeyName(): string
     {
         return 'slug';
+    }
+
+    /**
+     * Get feature flags configured for this tenant.
+     */
+    public function featureFlags(): BelongsToMany
+    {
+        return $this->belongsToMany(FeatureFlag::class, 'tenant_feature_flags')
+            ->withPivot('is_enabled')
+            ->withTimestamps();
+    }
+
+    /**
+     * Check if a feature is enabled for this tenant.
+     */
+    public function hasFeature(string $featureKey): bool
+    {
+        $feature = FeatureFlag::findByKey($featureKey);
+
+        if (! $feature) {
+            return false;
+        }
+
+        return $feature->isEnabledForTenant($this);
+    }
+
+    /**
+     * Enable a feature flag for this tenant.
+     */
+    public function enableFeature(string $featureKey): bool
+    {
+        $feature = FeatureFlag::findByKey($featureKey);
+
+        if (! $feature) {
+            return false;
+        }
+
+        $this->featureFlags()->syncWithoutDetaching([
+            $feature->id => ['is_enabled' => true],
+        ]);
+
+        return true;
+    }
+
+    /**
+     * Disable a feature flag for this tenant.
+     */
+    public function disableFeature(string $featureKey): bool
+    {
+        $feature = FeatureFlag::findByKey($featureKey);
+
+        if (! $feature) {
+            return false;
+        }
+
+        $this->featureFlags()->syncWithoutDetaching([
+            $feature->id => ['is_enabled' => false],
+        ]);
+
+        return true;
     }
 }

--- a/database/factories/FeatureFlagFactory.php
+++ b/database/factories/FeatureFlagFactory.php
@@ -1,0 +1,83 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Models\FeatureFlag;
+use Illuminate\Database\Eloquent\Factories\Factory;
+use Illuminate\Support\Str;
+
+/**
+ * @extends Factory<FeatureFlag>
+ */
+class FeatureFlagFactory extends Factory
+{
+    /**
+     * Define the model's default state.
+     *
+     * @return array<string, mixed>
+     */
+    public function definition(): array
+    {
+        $name = 'ENABLE_'.fake()->unique()->words(2, true);
+
+        return [
+            'key' => Str::upper(Str::snake($name)),
+            'name' => ucwords(str_replace('_', ' ', $name)),
+            'name_ar' => null,
+            'description' => fake()->sentence(),
+            'category' => fake()->randomElement(FeatureFlag::categories()),
+            'default_value' => fake()->boolean(70),
+            'is_active' => true,
+        ];
+    }
+
+    /**
+     * Create a feature flag for a specific category.
+     */
+    public function forCategory(string $category): static
+    {
+        return $this->state(fn (array $attributes) => [
+            'category' => $category,
+        ]);
+    }
+
+    /**
+     * Create an inactive feature flag.
+     */
+    public function inactive(): static
+    {
+        return $this->state(fn (array $attributes) => [
+            'is_active' => false,
+        ]);
+    }
+
+    /**
+     * Create a feature flag that is enabled by default.
+     */
+    public function enabledByDefault(): static
+    {
+        return $this->state(fn (array $attributes) => [
+            'default_value' => true,
+        ]);
+    }
+
+    /**
+     * Create a feature flag that is disabled by default.
+     */
+    public function disabledByDefault(): static
+    {
+        return $this->state(fn (array $attributes) => [
+            'default_value' => false,
+        ]);
+    }
+
+    /**
+     * Create a feature flag with a specific key.
+     */
+    public function withKey(string $key): static
+    {
+        return $this->state(fn (array $attributes) => [
+            'key' => $key,
+        ]);
+    }
+}

--- a/database/migrations/2026_04_13_023957_create_feature_flags_table.php
+++ b/database/migrations/2026_04_13_023957_create_feature_flags_table.php
@@ -1,0 +1,36 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('feature_flags', function (Blueprint $table) {
+            $table->id();
+            $table->string('key')->unique();
+            $table->string('name');
+            $table->string('name_ar')->nullable();
+            $table->text('description')->nullable();
+            $table->string('category');
+            $table->boolean('default_value')->default(false);
+            $table->boolean('is_active')->default(true);
+            $table->timestamps();
+
+            $table->index(['category', 'is_active']);
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('feature_flags');
+    }
+};

--- a/database/migrations/2026_04_13_024006_create_tenant_feature_flags_table.php
+++ b/database/migrations/2026_04_13_024006_create_tenant_feature_flags_table.php
@@ -1,0 +1,32 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('tenant_feature_flags', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('tenant_id')->constrained()->cascadeOnDelete();
+            $table->foreignId('feature_flag_id')->constrained()->cascadeOnDelete();
+            $table->boolean('is_enabled')->default(true);
+            $table->timestamps();
+
+            $table->unique(['tenant_id', 'feature_flag_id']);
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('tenant_feature_flags');
+    }
+};

--- a/database/seeders/DatabaseSeeder.php
+++ b/database/seeders/DatabaseSeeder.php
@@ -29,6 +29,7 @@ class DatabaseSeeder extends Seeder
             FacilityCategorySeeder::class,
             AmenitySeeder::class,
             StatusSeeder::class,
+            FeatureFlagSeeder::class,
         ]);
 
         // Create admin user

--- a/database/seeders/FeatureFlagSeeder.php
+++ b/database/seeders/FeatureFlagSeeder.php
@@ -1,0 +1,87 @@
+<?php
+
+namespace Database\Seeders;
+
+use App\Models\FeatureFlag;
+use Illuminate\Database\Seeder;
+
+class FeatureFlagSeeder extends Seeder
+{
+    /**
+     * Run the database seeds.
+     */
+    public function run(): void
+    {
+        $flags = [
+            // Contacts category
+            ['key' => 'ENABLE_ADMIN', 'name' => 'Enable Admin Management', 'name_ar' => 'تفعيل إدارة المشرفين', 'category' => 'contacts', 'default_value' => true],
+            ['key' => 'ENABLE_MANAGERS', 'name' => 'Enable Managers', 'name_ar' => 'تفعيل المديرين', 'category' => 'contacts', 'default_value' => true],
+            ['key' => 'ENABLE_PROFESSIONALS', 'name' => 'Enable Professionals', 'name_ar' => 'تفعيل المهنيين', 'category' => 'contacts', 'default_value' => true],
+            ['key' => 'ENABLE_TENANTS', 'name' => 'Enable Tenants', 'name_ar' => 'تفعيل المستأجرين', 'category' => 'contacts', 'default_value' => true],
+            ['key' => 'ENABLE_DEPENDENTS', 'name' => 'Enable Dependents', 'name_ar' => 'تفعيل المعالين', 'category' => 'contacts', 'default_value' => true],
+            ['key' => 'ENABLE_OWNERS', 'name' => 'Enable Owners', 'name_ar' => 'تفعيل الملاك', 'category' => 'contacts', 'default_value' => true],
+
+            // Properties category
+            ['key' => 'ENABLE_FACILITIES', 'name' => 'Enable Facilities', 'name_ar' => 'تفعيل المرافق', 'category' => 'properties', 'default_value' => true],
+            ['key' => 'ENABLE_ADD_COMMON_AREA', 'name' => 'Enable Add Common Area', 'name_ar' => 'تفعيل إضافة المناطق المشتركة', 'category' => 'properties', 'default_value' => true],
+            ['key' => 'ENABLE_COMMON_AREA_MANAGEMENT', 'name' => 'Enable Common Area Management', 'name_ar' => 'تفعيل إدارة المناطق المشتركة', 'category' => 'properties', 'default_value' => true],
+            ['key' => 'ENABLE_PROPERTY_DOCUMENTATION', 'name' => 'Enable Property Documentation', 'name_ar' => 'تفعيل توثيق العقارات', 'category' => 'properties', 'default_value' => true],
+            ['key' => 'ENABLE_PROPERTY_HANDOVER', 'name' => 'Enable Property Handover', 'name_ar' => 'تفعيل تسليم العقارات', 'category' => 'properties', 'default_value' => false],
+            ['key' => 'ENABLE_ASSIGN_UNIT_OWNER', 'name' => 'Enable Assign Unit Owner', 'name_ar' => 'تفعيل تعيين مالك الوحدة', 'category' => 'properties', 'default_value' => true],
+            ['key' => 'ENABLE_ASSIGN_UNIT_LEASE', 'name' => 'Enable Assign Unit Lease', 'name_ar' => 'تفعيل تعيين عقد الوحدة', 'category' => 'properties', 'default_value' => true],
+
+            // Leasing category
+            ['key' => 'CREATE_LEASES', 'name' => 'Create Leases', 'name_ar' => 'إنشاء العقود', 'category' => 'leasing', 'default_value' => true],
+            ['key' => 'MOVE_IN_TENANTS', 'name' => 'Move In Tenants', 'name_ar' => 'تسكين المستأجرين', 'category' => 'leasing', 'default_value' => true],
+            ['key' => 'MOVE_OUT_TENANTS', 'name' => 'Move Out Tenants', 'name_ar' => 'إخلاء المستأجرين', 'category' => 'leasing', 'default_value' => true],
+            ['key' => 'INTEGRATE_WITH_EJAR', 'name' => 'Integrate with Ejar', 'name_ar' => 'التكامل مع إيجار', 'category' => 'leasing', 'default_value' => true],
+            ['key' => 'ENABLE_AI_BASED_EJAR_CONTRACT_READER', 'name' => 'Enable AI Based Ejar Contract Reader', 'name_ar' => 'تفعيل قارئ العقود بالذكاء الاصطناعي', 'category' => 'leasing', 'default_value' => true],
+            ['key' => 'ENABLE_UPLOAD_EJAR', 'name' => 'Enable Upload Ejar', 'name_ar' => 'تفعيل رفع عقود إيجار', 'category' => 'leasing', 'default_value' => true],
+
+            // Transactions category
+            ['key' => 'ENABLE_RECORD_TRANSACTION', 'name' => 'Enable Record Transaction', 'name_ar' => 'تفعيل تسجيل المعاملات', 'category' => 'transactions', 'default_value' => true],
+            ['key' => 'ENABLE_RECORD_PAYMENT', 'name' => 'Enable Record Payment', 'name_ar' => 'تفعيل تسجيل المدفوعات', 'category' => 'transactions', 'default_value' => true],
+            ['key' => 'ENABLE_PAYMENT_RECEIPTS', 'name' => 'Enable Payment Receipts', 'name_ar' => 'تفعيل إيصالات الدفع', 'category' => 'transactions', 'default_value' => true],
+            ['key' => 'ENABLE_PAYMENT_REMINDER', 'name' => 'Enable Payment Reminder', 'name_ar' => 'تفعيل تذكير الدفع', 'category' => 'transactions', 'default_value' => true],
+            ['key' => 'ENABLE_E_INVOICE', 'name' => 'Enable E-Invoice', 'name_ar' => 'تفعيل الفاتورة الإلكترونية', 'category' => 'transactions', 'default_value' => true],
+            ['key' => 'ENABLE_ONLINE_PAYMENT', 'name' => 'Enable Online Payment', 'name_ar' => 'تفعيل الدفع الإلكتروني', 'category' => 'transactions', 'default_value' => true],
+
+            // Requests category
+            ['key' => 'ENABLE_REQUESTS', 'name' => 'Enable Requests', 'name_ar' => 'تفعيل الطلبات', 'category' => 'requests', 'default_value' => true],
+            ['key' => 'ENABLE_BOOKING_REQUESTS', 'name' => 'Enable Booking Requests', 'name_ar' => 'تفعيل طلبات الحجز', 'category' => 'requests', 'default_value' => true],
+            ['key' => 'ENABLE_SERVICES_SETTINGS', 'name' => 'Enable Services Settings', 'name_ar' => 'تفعيل إعدادات الخدمات', 'category' => 'requests', 'default_value' => true],
+            ['key' => 'ENABLE_VISITOR_ACCESS_MANAGEMENT', 'name' => 'Enable Visitor Access Management', 'name_ar' => 'تفعيل إدارة وصول الزوار', 'category' => 'requests', 'default_value' => true],
+            ['key' => 'ENABLE_SERVICE_PROVIDER', 'name' => 'Enable Service Provider', 'name_ar' => 'تفعيل مزود الخدمة', 'category' => 'requests', 'default_value' => true],
+            ['key' => 'ENABLE_SUGGESTION', 'name' => 'Enable Suggestion', 'name_ar' => 'تفعيل الاقتراحات', 'category' => 'requests', 'default_value' => true],
+
+            // Communication category
+            ['key' => 'ENABLE_OFFERS', 'name' => 'Enable Offers', 'name_ar' => 'تفعيل العروض', 'category' => 'communication', 'default_value' => true],
+            ['key' => 'ENABLE_SEND_ANNOUNCEMENT', 'name' => 'Enable Send Announcement', 'name_ar' => 'تفعيل إرسال الإعلانات', 'category' => 'communication', 'default_value' => true],
+            ['key' => 'ENABLE_DIRECTORY', 'name' => 'Enable Directory', 'name_ar' => 'تفعيل الدليل', 'category' => 'communication', 'default_value' => true],
+            ['key' => 'ENABLE_PUSH_NOTIFICATION', 'name' => 'Enable Push Notification', 'name_ar' => 'تفعيل الإشعارات', 'category' => 'communication', 'default_value' => true],
+            ['key' => 'ENABLE_SEND_SMS', 'name' => 'Enable Send SMS', 'name_ar' => 'تفعيل إرسال الرسائل', 'category' => 'communication', 'default_value' => true],
+            ['key' => 'ENABLE_WHATSAPP_BUSINESS', 'name' => 'Enable WhatsApp Business', 'name_ar' => 'تفعيل واتساب بزنس', 'category' => 'communication', 'default_value' => true],
+
+            // Reports category
+            ['key' => 'ENABLE_DASHBOARD', 'name' => 'Enable Dashboard', 'name_ar' => 'تفعيل لوحة التحكم', 'category' => 'reports', 'default_value' => true],
+            ['key' => 'ENABLE_REQUIRE_ATTENTION', 'name' => 'Enable Require Attention', 'name_ar' => 'تفعيل يتطلب الانتباه', 'category' => 'reports', 'default_value' => true],
+            ['key' => 'ENABLE_MEASURE_PERFORMANCE', 'name' => 'Enable Measure Performance', 'name_ar' => 'تفعيل قياس الأداء', 'category' => 'reports', 'default_value' => true],
+            ['key' => 'ENABLE_LEASE_REPORT', 'name' => 'Enable Lease Report', 'name_ar' => 'تفعيل تقرير العقود', 'category' => 'reports', 'default_value' => true],
+            ['key' => 'ENABLE_FINANCIAL_REPORT', 'name' => 'Enable Financial Report', 'name_ar' => 'تفعيل التقرير المالي', 'category' => 'reports', 'default_value' => true],
+            ['key' => 'ENABLE_TENANT_REPORT', 'name' => 'Enable Tenant Report', 'name_ar' => 'تفعيل تقرير المستأجرين', 'category' => 'reports', 'default_value' => true],
+            ['key' => 'ENABLE_MAINTENANCE_REPORT', 'name' => 'Enable Maintenance Report', 'name_ar' => 'تفعيل تقرير الصيانة', 'category' => 'reports', 'default_value' => true],
+
+            // Tools category
+            ['key' => 'ENABLE_TOOLS', 'name' => 'Enable Tools', 'name_ar' => 'تفعيل الأدوات', 'category' => 'tools', 'default_value' => true],
+            ['key' => 'ENABLE_TOOLS_SETTINGS', 'name' => 'Enable Tools Settings', 'name_ar' => 'تفعيل إعدادات الأدوات', 'category' => 'tools', 'default_value' => true],
+            ['key' => 'ENABLE_FORM_SETTINGS', 'name' => 'Enable Form Settings', 'name_ar' => 'تفعيل إعدادات النماذج', 'category' => 'tools', 'default_value' => true],
+        ];
+
+        foreach ($flags as $flag) {
+            FeatureFlag::updateOrCreate(
+                ['key' => $flag['key']],
+                array_merge($flag, ['is_active' => true])
+            );
+        }
+    }
+}

--- a/tests/Feature/FeatureFlagSystemTest.php
+++ b/tests/Feature/FeatureFlagSystemTest.php
@@ -1,0 +1,536 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\FeatureFlag;
+use App\Models\Tenant;
+use Database\Seeders\FeatureFlagSeeder;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class FeatureFlagSystemTest extends TestCase
+{
+    use RefreshDatabase;
+
+    // ==========================================
+    // FeatureFlag Model Tests
+    // ==========================================
+
+    public function test_feature_flag_has_correct_fillable_attributes(): void
+    {
+        $flag = FeatureFlag::factory()->create([
+            'key' => 'TEST_FEATURE',
+            'name' => 'Test Feature',
+            'name_ar' => 'ميزة الاختبار',
+            'description' => 'A test feature flag',
+            'category' => FeatureFlag::CATEGORY_CONTACTS,
+            'default_value' => true,
+            'is_active' => true,
+        ]);
+
+        $this->assertEquals('TEST_FEATURE', $flag->key);
+        $this->assertEquals('Test Feature', $flag->name);
+        $this->assertEquals('ميزة الاختبار', $flag->name_ar);
+        $this->assertEquals('A test feature flag', $flag->description);
+        $this->assertEquals('contacts', $flag->category);
+        $this->assertTrue($flag->default_value);
+        $this->assertTrue($flag->is_active);
+    }
+
+    public function test_feature_flag_casts_boolean_attributes(): void
+    {
+        $flag = FeatureFlag::factory()->create([
+            'default_value' => 1,
+            'is_active' => 0,
+        ]);
+
+        $this->assertIsBool($flag->default_value);
+        $this->assertIsBool($flag->is_active);
+        $this->assertTrue($flag->default_value);
+        $this->assertFalse($flag->is_active);
+    }
+
+    public function test_feature_flag_has_category_constants(): void
+    {
+        $this->assertEquals('contacts', FeatureFlag::CATEGORY_CONTACTS);
+        $this->assertEquals('properties', FeatureFlag::CATEGORY_PROPERTIES);
+        $this->assertEquals('leasing', FeatureFlag::CATEGORY_LEASING);
+        $this->assertEquals('transactions', FeatureFlag::CATEGORY_TRANSACTIONS);
+        $this->assertEquals('requests', FeatureFlag::CATEGORY_REQUESTS);
+        $this->assertEquals('communication', FeatureFlag::CATEGORY_COMMUNICATION);
+        $this->assertEquals('reports', FeatureFlag::CATEGORY_REPORTS);
+        $this->assertEquals('tools', FeatureFlag::CATEGORY_TOOLS);
+        $this->assertEquals('integrations', FeatureFlag::CATEGORY_INTEGRATIONS);
+        $this->assertEquals('marketplace', FeatureFlag::CATEGORY_MARKETPLACE);
+    }
+
+    public function test_feature_flag_categories_method_returns_all_categories(): void
+    {
+        $categories = FeatureFlag::categories();
+
+        $this->assertIsArray($categories);
+        $this->assertCount(10, $categories);
+        $this->assertContains('contacts', $categories);
+        $this->assertContains('properties', $categories);
+        $this->assertContains('leasing', $categories);
+        $this->assertContains('transactions', $categories);
+        $this->assertContains('requests', $categories);
+        $this->assertContains('communication', $categories);
+        $this->assertContains('reports', $categories);
+        $this->assertContains('tools', $categories);
+        $this->assertContains('integrations', $categories);
+        $this->assertContains('marketplace', $categories);
+    }
+
+    public function test_feature_flag_find_by_key_returns_feature(): void
+    {
+        $flag = FeatureFlag::factory()->create(['key' => 'ENABLE_TENANTS']);
+
+        $found = FeatureFlag::findByKey('ENABLE_TENANTS');
+
+        $this->assertNotNull($found);
+        $this->assertEquals($flag->id, $found->id);
+    }
+
+    public function test_feature_flag_find_by_key_returns_null_for_nonexistent(): void
+    {
+        $found = FeatureFlag::findByKey('NONEXISTENT_KEY');
+
+        $this->assertNull($found);
+    }
+
+    // ==========================================
+    // FeatureFlag Scope Tests
+    // ==========================================
+
+    public function test_feature_flag_active_scope(): void
+    {
+        FeatureFlag::factory()->count(3)->create(['is_active' => true]);
+        FeatureFlag::factory()->count(2)->create(['is_active' => false]);
+
+        $activeFlags = FeatureFlag::active()->get();
+
+        $this->assertCount(3, $activeFlags);
+    }
+
+    public function test_feature_flag_for_category_scope(): void
+    {
+        FeatureFlag::factory()->count(3)->forCategory('contacts')->create();
+        FeatureFlag::factory()->count(2)->forCategory('leasing')->create();
+
+        $contactsFlags = FeatureFlag::forCategory('contacts')->get();
+        $leasingFlags = FeatureFlag::forCategory('leasing')->get();
+
+        $this->assertCount(3, $contactsFlags);
+        $this->assertCount(2, $leasingFlags);
+    }
+
+    public function test_feature_flag_enabled_by_default_scope(): void
+    {
+        FeatureFlag::factory()->count(3)->enabledByDefault()->create();
+        FeatureFlag::factory()->count(2)->disabledByDefault()->create();
+
+        $enabledByDefault = FeatureFlag::enabledByDefault()->get();
+
+        $this->assertCount(3, $enabledByDefault);
+    }
+
+    // ==========================================
+    // FeatureFlag Tenant Relationship Tests
+    // ==========================================
+
+    public function test_feature_flag_belongs_to_many_tenants(): void
+    {
+        $flag = FeatureFlag::factory()->create();
+        $tenant = Tenant::factory()->create();
+
+        $flag->tenants()->attach($tenant->id, ['is_enabled' => true]);
+
+        $this->assertCount(1, $flag->tenants);
+        $this->assertEquals($tenant->id, $flag->tenants->first()->id);
+        $this->assertEquals(1, $flag->tenants->first()->pivot->is_enabled);
+    }
+
+    public function test_feature_flag_is_enabled_for_tenant_when_override_exists(): void
+    {
+        $flag = FeatureFlag::factory()->create([
+            'default_value' => false,
+            'is_active' => true,
+        ]);
+        $tenant = Tenant::factory()->create();
+
+        // Override to enabled
+        $flag->tenants()->attach($tenant->id, ['is_enabled' => true]);
+
+        $this->assertTrue($flag->isEnabledForTenant($tenant));
+    }
+
+    public function test_feature_flag_is_disabled_for_tenant_when_override_exists(): void
+    {
+        $flag = FeatureFlag::factory()->create([
+            'default_value' => true,
+            'is_active' => true,
+        ]);
+        $tenant = Tenant::factory()->create();
+
+        // Override to disabled
+        $flag->tenants()->attach($tenant->id, ['is_enabled' => false]);
+
+        $this->assertFalse($flag->isEnabledForTenant($tenant));
+    }
+
+    public function test_feature_flag_uses_default_value_when_no_override(): void
+    {
+        $enabledFlag = FeatureFlag::factory()->create([
+            'default_value' => true,
+            'is_active' => true,
+        ]);
+        $disabledFlag = FeatureFlag::factory()->create([
+            'default_value' => false,
+            'is_active' => true,
+        ]);
+        $tenant = Tenant::factory()->create();
+
+        $this->assertTrue($enabledFlag->isEnabledForTenant($tenant));
+        $this->assertFalse($disabledFlag->isEnabledForTenant($tenant));
+    }
+
+    public function test_feature_flag_returns_default_value_when_null_tenant(): void
+    {
+        $enabledFlag = FeatureFlag::factory()->create([
+            'default_value' => true,
+            'is_active' => true,
+        ]);
+        $disabledFlag = FeatureFlag::factory()->create([
+            'default_value' => false,
+            'is_active' => true,
+        ]);
+
+        $this->assertTrue($enabledFlag->isEnabledForTenant(null));
+        $this->assertFalse($disabledFlag->isEnabledForTenant(null));
+    }
+
+    public function test_feature_flag_returns_false_when_inactive(): void
+    {
+        $flag = FeatureFlag::factory()->create([
+            'default_value' => true,
+            'is_active' => false,
+        ]);
+        $tenant = Tenant::factory()->create();
+
+        $this->assertFalse($flag->isEnabledForTenant($tenant));
+        $this->assertFalse($flag->isEnabledForTenant(null));
+    }
+
+    // ==========================================
+    // Tenant Feature Flag Relationship Tests
+    // ==========================================
+
+    public function test_tenant_has_feature_flags_relationship(): void
+    {
+        $tenant = Tenant::factory()->create();
+        $flag = FeatureFlag::factory()->create();
+
+        $tenant->featureFlags()->attach($flag->id, ['is_enabled' => true]);
+
+        $this->assertCount(1, $tenant->featureFlags);
+        $this->assertEquals($flag->id, $tenant->featureFlags->first()->id);
+    }
+
+    public function test_tenant_has_feature_returns_true_when_enabled(): void
+    {
+        $tenant = Tenant::factory()->create();
+        $flag = FeatureFlag::factory()->create([
+            'key' => 'ENABLE_TENANTS',
+            'default_value' => true,
+            'is_active' => true,
+        ]);
+
+        $this->assertTrue($tenant->hasFeature('ENABLE_TENANTS'));
+    }
+
+    public function test_tenant_has_feature_returns_false_when_disabled(): void
+    {
+        $tenant = Tenant::factory()->create();
+        $flag = FeatureFlag::factory()->create([
+            'key' => 'ENABLE_FEATURE',
+            'default_value' => false,
+            'is_active' => true,
+        ]);
+
+        $this->assertFalse($tenant->hasFeature('ENABLE_FEATURE'));
+    }
+
+    public function test_tenant_has_feature_returns_false_for_nonexistent_key(): void
+    {
+        $tenant = Tenant::factory()->create();
+
+        $this->assertFalse($tenant->hasFeature('NONEXISTENT_KEY'));
+    }
+
+    public function test_tenant_enable_feature_creates_override(): void
+    {
+        $tenant = Tenant::factory()->create();
+        $flag = FeatureFlag::factory()->create([
+            'key' => 'ENABLE_FEATURE',
+            'default_value' => false,
+            'is_active' => true,
+        ]);
+
+        $result = $tenant->enableFeature('ENABLE_FEATURE');
+
+        $this->assertTrue($result);
+        $this->assertTrue($tenant->hasFeature('ENABLE_FEATURE'));
+    }
+
+    public function test_tenant_enable_feature_returns_false_for_nonexistent_key(): void
+    {
+        $tenant = Tenant::factory()->create();
+
+        $result = $tenant->enableFeature('NONEXISTENT_KEY');
+
+        $this->assertFalse($result);
+    }
+
+    public function test_tenant_disable_feature_creates_override(): void
+    {
+        $tenant = Tenant::factory()->create();
+        $flag = FeatureFlag::factory()->create([
+            'key' => 'ENABLE_FEATURE',
+            'default_value' => true,
+            'is_active' => true,
+        ]);
+
+        $result = $tenant->disableFeature('ENABLE_FEATURE');
+
+        $this->assertTrue($result);
+        $this->assertFalse($tenant->hasFeature('ENABLE_FEATURE'));
+    }
+
+    public function test_tenant_disable_feature_returns_false_for_nonexistent_key(): void
+    {
+        $tenant = Tenant::factory()->create();
+
+        $result = $tenant->disableFeature('NONEXISTENT_KEY');
+
+        $this->assertFalse($result);
+    }
+
+    public function test_tenant_can_toggle_feature_multiple_times(): void
+    {
+        $tenant = Tenant::factory()->create();
+        $flag = FeatureFlag::factory()->create([
+            'key' => 'ENABLE_FEATURE',
+            'default_value' => false,
+            'is_active' => true,
+        ]);
+
+        // Initially disabled by default
+        $this->assertFalse($tenant->hasFeature('ENABLE_FEATURE'));
+
+        // Enable
+        $tenant->enableFeature('ENABLE_FEATURE');
+        $this->assertTrue($tenant->hasFeature('ENABLE_FEATURE'));
+
+        // Disable
+        $tenant->disableFeature('ENABLE_FEATURE');
+        $this->assertFalse($tenant->hasFeature('ENABLE_FEATURE'));
+
+        // Enable again
+        $tenant->enableFeature('ENABLE_FEATURE');
+        $this->assertTrue($tenant->hasFeature('ENABLE_FEATURE'));
+    }
+
+    // ==========================================
+    // Multi-tenant Isolation Tests
+    // ==========================================
+
+    public function test_feature_flag_overrides_are_tenant_isolated(): void
+    {
+        $tenant1 = Tenant::factory()->create();
+        $tenant2 = Tenant::factory()->create();
+        $flag = FeatureFlag::factory()->create([
+            'key' => 'ENABLE_FEATURE',
+            'default_value' => false,
+            'is_active' => true,
+        ]);
+
+        // Enable for tenant1 only
+        $tenant1->enableFeature('ENABLE_FEATURE');
+
+        $this->assertTrue($tenant1->hasFeature('ENABLE_FEATURE'));
+        $this->assertFalse($tenant2->hasFeature('ENABLE_FEATURE'));
+    }
+
+    public function test_different_tenants_can_have_different_feature_settings(): void
+    {
+        $tenant1 = Tenant::factory()->create();
+        $tenant2 = Tenant::factory()->create();
+        $tenant3 = Tenant::factory()->create();
+
+        $flag = FeatureFlag::factory()->create([
+            'key' => 'ENABLE_FEATURE',
+            'default_value' => true,
+            'is_active' => true,
+        ]);
+
+        // Tenant1 uses default (enabled)
+        // Tenant2 explicitly disables
+        // Tenant3 explicitly enables
+        $tenant2->disableFeature('ENABLE_FEATURE');
+        $tenant3->enableFeature('ENABLE_FEATURE');
+
+        $this->assertTrue($tenant1->hasFeature('ENABLE_FEATURE')); // default
+        $this->assertFalse($tenant2->hasFeature('ENABLE_FEATURE')); // override
+        $this->assertTrue($tenant3->hasFeature('ENABLE_FEATURE')); // override
+    }
+
+    // ==========================================
+    // Factory State Tests
+    // ==========================================
+
+    public function test_factory_creates_valid_feature_flag(): void
+    {
+        $flag = FeatureFlag::factory()->create();
+
+        $this->assertNotNull($flag->id);
+        $this->assertNotEmpty($flag->key);
+        $this->assertNotEmpty($flag->name);
+        $this->assertContains($flag->category, FeatureFlag::categories());
+        $this->assertIsBool($flag->default_value);
+        $this->assertTrue($flag->is_active);
+    }
+
+    public function test_factory_for_category_state(): void
+    {
+        $flag = FeatureFlag::factory()->forCategory('leasing')->create();
+
+        $this->assertEquals('leasing', $flag->category);
+    }
+
+    public function test_factory_inactive_state(): void
+    {
+        $flag = FeatureFlag::factory()->inactive()->create();
+
+        $this->assertFalse($flag->is_active);
+    }
+
+    public function test_factory_enabled_by_default_state(): void
+    {
+        $flag = FeatureFlag::factory()->enabledByDefault()->create();
+
+        $this->assertTrue($flag->default_value);
+    }
+
+    public function test_factory_disabled_by_default_state(): void
+    {
+        $flag = FeatureFlag::factory()->disabledByDefault()->create();
+
+        $this->assertFalse($flag->default_value);
+    }
+
+    public function test_factory_with_key_state(): void
+    {
+        $flag = FeatureFlag::factory()->withKey('CUSTOM_KEY')->create();
+
+        $this->assertEquals('CUSTOM_KEY', $flag->key);
+    }
+
+    // ==========================================
+    // Seeder Tests
+    // ==========================================
+
+    public function test_seeder_creates_feature_flags(): void
+    {
+        $this->seed(FeatureFlagSeeder::class);
+
+        $this->assertGreaterThan(40, FeatureFlag::count());
+    }
+
+    public function test_seeder_creates_flags_for_all_categories(): void
+    {
+        $this->seed(FeatureFlagSeeder::class);
+
+        // Check contacts category
+        $this->assertGreaterThan(0, FeatureFlag::forCategory('contacts')->count());
+
+        // Check properties category
+        $this->assertGreaterThan(0, FeatureFlag::forCategory('properties')->count());
+
+        // Check leasing category
+        $this->assertGreaterThan(0, FeatureFlag::forCategory('leasing')->count());
+
+        // Check transactions category
+        $this->assertGreaterThan(0, FeatureFlag::forCategory('transactions')->count());
+
+        // Check requests category
+        $this->assertGreaterThan(0, FeatureFlag::forCategory('requests')->count());
+
+        // Check communication category
+        $this->assertGreaterThan(0, FeatureFlag::forCategory('communication')->count());
+
+        // Check reports category
+        $this->assertGreaterThan(0, FeatureFlag::forCategory('reports')->count());
+
+        // Check tools category
+        $this->assertGreaterThan(0, FeatureFlag::forCategory('tools')->count());
+    }
+
+    public function test_seeder_creates_specific_feature_flags(): void
+    {
+        $this->seed(FeatureFlagSeeder::class);
+
+        // Contacts
+        $this->assertNotNull(FeatureFlag::findByKey('ENABLE_ADMIN'));
+        $this->assertNotNull(FeatureFlag::findByKey('ENABLE_TENANTS'));
+        $this->assertNotNull(FeatureFlag::findByKey('ENABLE_OWNERS'));
+
+        // Properties
+        $this->assertNotNull(FeatureFlag::findByKey('ENABLE_FACILITIES'));
+
+        // Leasing
+        $this->assertNotNull(FeatureFlag::findByKey('CREATE_LEASES'));
+        $this->assertNotNull(FeatureFlag::findByKey('INTEGRATE_WITH_EJAR'));
+
+        // Transactions
+        $this->assertNotNull(FeatureFlag::findByKey('ENABLE_ONLINE_PAYMENT'));
+        $this->assertNotNull(FeatureFlag::findByKey('ENABLE_E_INVOICE'));
+
+        // Communication
+        $this->assertNotNull(FeatureFlag::findByKey('ENABLE_PUSH_NOTIFICATION'));
+        $this->assertNotNull(FeatureFlag::findByKey('ENABLE_WHATSAPP_BUSINESS'));
+
+        // Reports
+        $this->assertNotNull(FeatureFlag::findByKey('ENABLE_DASHBOARD'));
+    }
+
+    public function test_seeder_is_idempotent(): void
+    {
+        $this->seed(FeatureFlagSeeder::class);
+        $firstCount = FeatureFlag::count();
+
+        $this->seed(FeatureFlagSeeder::class);
+        $secondCount = FeatureFlag::count();
+
+        $this->assertEquals($firstCount, $secondCount);
+    }
+
+    public function test_seeded_flags_have_arabic_names(): void
+    {
+        $this->seed(FeatureFlagSeeder::class);
+
+        $flag = FeatureFlag::findByKey('ENABLE_ADMIN');
+
+        $this->assertNotNull($flag->name_ar);
+        $this->assertEquals('تفعيل إدارة المشرفين', $flag->name_ar);
+    }
+
+    public function test_seeded_flags_are_all_active(): void
+    {
+        $this->seed(FeatureFlagSeeder::class);
+
+        $inactiveCount = FeatureFlag::where('is_active', false)->count();
+
+        $this->assertEquals(0, $inactiveCount);
+    }
+}


### PR DESCRIPTION
## Summary

Implements the unified feature flags system per PRD Issue #9:

- **FeatureFlag Model**: 10 category constants, tenant relationships, scopes, and helper methods
- **Multi-tenant Support**: Tenant-specific overrides via pivot table with isolated feature settings
- **47 Feature Flags**: Organized across 8 categories (contacts, properties, leasing, transactions, requests, communication, reports, tools)
- **Arabic Translations**: All flags include `name_ar` for localization
- **Comprehensive Tests**: 38 tests with 106 assertions covering all functionality

## Key Features

### Categories
- `contacts` (6 flags): Admin, Managers, Professionals, Tenants, Dependents, Owners
- `properties` (6 flags): Facilities, Common Areas, Documentation, Handover, Unit Owner/Lease
- `leasing` (6 flags): Create/Move-in/Move-out, Ejar Integration, AI Contract Reader
- `transactions` (6 flags): Record Transaction/Payment, Receipts, Reminders, E-Invoice, Online Payment
- `requests` (6 flags): Requests, Bookings, Services Settings, Visitor Access, Suggestions
- `communication` (6 flags): Offers, Announcements, Directory, Push/SMS/WhatsApp
- `reports` (7 flags): Dashboard, Attention, Performance, Lease/Financial/Tenant/Maintenance Reports
- `tools` (3 flags): Tools, Settings, Form Settings

### Tenant Helper Methods
- `$tenant->hasFeature('ENABLE_TENANTS')` - Check if feature is enabled
- `$tenant->enableFeature('ENABLE_TENANTS')` - Override feature to enabled
- `$tenant->disableFeature('ENABLE_TENANTS')` - Override feature to disabled

### Isolation
- Each tenant can have different feature settings
- Falls back to `default_value` when no override exists
- Inactive features always return `false` for all tenants

## Test plan

- [x] Run `php artisan test tests/Feature/FeatureFlagSystemTest.php` - 38 tests pass
- [x] Run `php artisan migrate:fresh --seed` - All migrations and seeders work
- [x] Run `vendor/bin/pint --format agent` - Code formatted

## Files Changed

- `app/Models/FeatureFlag.php` - New model
- `app/Models/Tenant.php` - Added feature flag relationships
- `database/migrations/*_create_feature_flags_table.php` - New migration
- `database/migrations/*_create_tenant_feature_flags_table.php` - New pivot migration
- `database/factories/FeatureFlagFactory.php` - New factory
- `database/seeders/FeatureFlagSeeder.php` - New seeder with 47 flags
- `database/seeders/DatabaseSeeder.php` - Added FeatureFlagSeeder
- `tests/Feature/FeatureFlagSystemTest.php` - 38 comprehensive tests

Closes #9

🤖 Generated with [Claude Code](https://claude.com/claude-code)