### PR TITLE
Issue #11: Buildings Entity

### DIFF
--- a/app/Models/Building.php
+++ b/app/Models/Building.php
@@ -1,10 +1,222 @@
 <?php
 
+declare(strict_types=1);
+
 namespace App\Models;
 
+use Database\Factories\BuildingFactory;
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Database\Eloquent\Relations\HasMany;
+use Illuminate\Database\Eloquent\SoftDeletes;
 
+/**
+ * Represents a physical building within a community.
+ *
+ * Buildings are the second level in the property hierarchy:
+ * Community → Building → Unit
+ */
 class Building extends Model
 {
-    //
+    /** @use HasFactory<BuildingFactory> */
+    use HasFactory, SoftDeletes;
+
+    // Status constants
+    public const STATUS_ACTIVE = 'active';
+
+    public const STATUS_INACTIVE = 'inactive';
+
+    /**
+     * The attributes that are mass assignable.
+     *
+     * @var list<string>
+     */
+    protected $fillable = [
+        'tenant_id',
+        'community_id',
+        'name',
+        'city_id',
+        'district_id',
+        'no_floors',
+        'year_built',
+        'map',
+        'status',
+    ];
+
+    /**
+     * Get the attributes that should be cast.
+     *
+     * @return array<string, string>
+     */
+    protected function casts(): array
+    {
+        return [
+            'no_floors' => 'integer',
+            'year_built' => 'integer',
+            'map' => 'array',
+        ];
+    }
+
+    // ==========================================
+    // Relationships
+    // ==========================================
+
+    /**
+     * Get the tenant that owns this building.
+     */
+    public function tenant(): BelongsTo
+    {
+        return $this->belongsTo(Tenant::class);
+    }
+
+    /**
+     * Get the community this building belongs to.
+     */
+    public function community(): BelongsTo
+    {
+        return $this->belongsTo(Community::class);
+    }
+
+    /**
+     * Get the city where this building is located.
+     */
+    public function city(): BelongsTo
+    {
+        return $this->belongsTo(City::class);
+    }
+
+    /**
+     * Get the district where this building is located.
+     */
+    public function district(): BelongsTo
+    {
+        return $this->belongsTo(District::class);
+    }
+
+    /**
+     * Get the units in this building.
+     */
+    public function units(): HasMany
+    {
+        return $this->hasMany(Unit::class);
+    }
+
+    // ==========================================
+    // Scopes
+    // ==========================================
+
+    /**
+     * Scope to filter active buildings.
+     */
+    public function scopeActive(Builder $query): Builder
+    {
+        return $query->where('status', self::STATUS_ACTIVE);
+    }
+
+    /**
+     * Scope to filter inactive buildings.
+     */
+    public function scopeInactive(Builder $query): Builder
+    {
+        return $query->where('status', self::STATUS_INACTIVE);
+    }
+
+    /**
+     * Scope to filter buildings for a specific tenant.
+     */
+    public function scopeForTenant(Builder $query, Tenant|int $tenant): Builder
+    {
+        $tenantId = $tenant instanceof Tenant ? $tenant->id : $tenant;
+
+        return $query->where('tenant_id', $tenantId);
+    }
+
+    /**
+     * Scope to filter buildings for a specific community.
+     */
+    public function scopeForCommunity(Builder $query, Community|int $community): Builder
+    {
+        $communityId = $community instanceof Community ? $community->id : $community;
+
+        return $query->where('community_id', $communityId);
+    }
+
+    /**
+     * Scope to filter buildings in a specific city.
+     */
+    public function scopeInCity(Builder $query, City|int $city): Builder
+    {
+        $cityId = $city instanceof City ? $city->id : $city;
+
+        return $query->where('city_id', $cityId);
+    }
+
+    /**
+     * Scope to filter buildings in a specific district.
+     */
+    public function scopeInDistrict(Builder $query, District|int $district): Builder
+    {
+        $districtId = $district instanceof District ? $district->id : $district;
+
+        return $query->where('district_id', $districtId);
+    }
+
+    // ==========================================
+    // Helper Methods
+    // ==========================================
+
+    /**
+     * Check if the building is active.
+     */
+    public function isActive(): bool
+    {
+        return $this->status === self::STATUS_ACTIVE;
+    }
+
+    /**
+     * Check if the building is inactive.
+     */
+    public function isInactive(): bool
+    {
+        return $this->status === self::STATUS_INACTIVE;
+    }
+
+    /**
+     * Activate the building.
+     */
+    public function activate(): bool
+    {
+        return $this->update(['status' => self::STATUS_ACTIVE]);
+    }
+
+    /**
+     * Deactivate the building.
+     */
+    public function deactivate(): bool
+    {
+        return $this->update(['status' => self::STATUS_INACTIVE]);
+    }
+
+    /**
+     * Get all available statuses.
+     *
+     * @return array<string>
+     */
+    public static function statuses(): array
+    {
+        return [
+            self::STATUS_ACTIVE,
+            self::STATUS_INACTIVE,
+        ];
+    }
+
+    /**
+     * Get the count of units in this building.
+     */
+    public function getUnitsCountAttribute(): int
+    {
+        return $this->units()->count();
+    }
 }

--- a/app/Models/Unit.php
+++ b/app/Models/Unit.php
@@ -1,0 +1,67 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Models;
+
+use Database\Factories\UnitFactory;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Database\Eloquent\SoftDeletes;
+
+/**
+ * Represents a rentable/sellable unit within a building.
+ *
+ * Units are the third level in the property hierarchy:
+ * Community → Building → Unit
+ *
+ * Note: This is a minimal stub to support Building relationship tests.
+ * Full Unit entity will be implemented in Issue #12.
+ */
+class Unit extends Model
+{
+    /** @use HasFactory<UnitFactory> */
+    use HasFactory, SoftDeletes;
+
+    /**
+     * The attributes that are mass assignable.
+     *
+     * @var list<string>
+     */
+    protected $fillable = [
+        'tenant_id',
+        'community_id',
+        'building_id',
+        'name',
+        'status',
+    ];
+
+    // ==========================================
+    // Relationships
+    // ==========================================
+
+    /**
+     * Get the tenant that owns this unit.
+     */
+    public function tenant(): BelongsTo
+    {
+        return $this->belongsTo(Tenant::class);
+    }
+
+    /**
+     * Get the community this unit belongs to.
+     */
+    public function community(): BelongsTo
+    {
+        return $this->belongsTo(Community::class);
+    }
+
+    /**
+     * Get the building this unit is in.
+     */
+    public function building(): BelongsTo
+    {
+        return $this->belongsTo(Building::class);
+    }
+}

--- a/database/factories/BuildingFactory.php
+++ b/database/factories/BuildingFactory.php
@@ -1,0 +1,152 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Models\Building;
+use App\Models\City;
+use App\Models\Community;
+use App\Models\District;
+use App\Models\Tenant;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+/**
+ * @extends Factory<Building>
+ */
+class BuildingFactory extends Factory
+{
+    /**
+     * Define the model's default state.
+     *
+     * @return array<string, mixed>
+     */
+    public function definition(): array
+    {
+        return [
+            'tenant_id' => Tenant::factory(),
+            'community_id' => Community::factory(),
+            'name' => fake()->randomElement(['Building', 'Tower', 'Block', 'Villa']).' '.fake()->randomLetter().fake()->numberBetween(1, 99),
+            'city_id' => City::factory(),
+            'district_id' => District::factory(),
+            'no_floors' => fake()->numberBetween(1, 50),
+            'year_built' => fake()->optional(0.7)->numberBetween(1990, 2025),
+            'map' => null,
+            'status' => Building::STATUS_ACTIVE,
+        ];
+    }
+
+    /**
+     * Set the building as active.
+     */
+    public function active(): static
+    {
+        return $this->state(fn (array $attributes) => [
+            'status' => Building::STATUS_ACTIVE,
+        ]);
+    }
+
+    /**
+     * Set the building as inactive.
+     */
+    public function inactive(): static
+    {
+        return $this->state(fn (array $attributes) => [
+            'status' => Building::STATUS_INACTIVE,
+        ]);
+    }
+
+    /**
+     * Set the building for a specific tenant.
+     */
+    public function forTenant(Tenant $tenant): static
+    {
+        return $this->state(fn (array $attributes) => [
+            'tenant_id' => $tenant->id,
+        ]);
+    }
+
+    /**
+     * Set the building for a specific community.
+     */
+    public function forCommunity(Community $community): static
+    {
+        return $this->state(fn (array $attributes) => [
+            'community_id' => $community->id,
+            'tenant_id' => $community->tenant_id,
+        ]);
+    }
+
+    /**
+     * Set the building in a specific city.
+     */
+    public function inCity(City $city): static
+    {
+        return $this->state(fn (array $attributes) => [
+            'city_id' => $city->id,
+        ]);
+    }
+
+    /**
+     * Set the building in a specific district.
+     */
+    public function inDistrict(District $district): static
+    {
+        return $this->state(fn (array $attributes) => [
+            'district_id' => $district->id,
+        ]);
+    }
+
+    /**
+     * Set the number of floors.
+     */
+    public function withFloors(int $floors): static
+    {
+        return $this->state(fn (array $attributes) => [
+            'no_floors' => $floors,
+        ]);
+    }
+
+    /**
+     * Set the year built.
+     */
+    public function builtIn(int $year): static
+    {
+        return $this->state(fn (array $attributes) => [
+            'year_built' => $year,
+        ]);
+    }
+
+    /**
+     * Set map coordinates.
+     */
+    public function withMap(float $latitude, float $longitude): static
+    {
+        return $this->state(fn (array $attributes) => [
+            'map' => [
+                'latitude' => $latitude,
+                'longitude' => $longitude,
+            ],
+        ]);
+    }
+
+    /**
+     * Create a building as a tower (high-rise).
+     */
+    public function tower(): static
+    {
+        return $this->state(fn (array $attributes) => [
+            'name' => 'Tower '.fake()->randomLetter().fake()->numberBetween(1, 99),
+            'no_floors' => fake()->numberBetween(20, 100),
+        ]);
+    }
+
+    /**
+     * Create a building as a villa.
+     */
+    public function villa(): static
+    {
+        return $this->state(fn (array $attributes) => [
+            'name' => 'Villa '.fake()->numberBetween(1, 999),
+            'no_floors' => fake()->numberBetween(1, 3),
+        ]);
+    }
+}

--- a/database/factories/UnitFactory.php
+++ b/database/factories/UnitFactory.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Models\Building;
+use App\Models\Community;
+use App\Models\Tenant;
+use App\Models\Unit;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+/**
+ * @extends Factory<Unit>
+ *
+ * Note: This is a minimal factory stub to support Building relationship tests.
+ * Full Unit factory will be implemented in Issue #12.
+ */
+class UnitFactory extends Factory
+{
+    /**
+     * Define the model's default state.
+     *
+     * @return array<string, mixed>
+     */
+    public function definition(): array
+    {
+        return [
+            'tenant_id' => Tenant::factory(),
+            'community_id' => Community::factory(),
+            'building_id' => Building::factory(),
+            'name' => 'Unit '.fake()->numberBetween(100, 9999),
+            'status' => 'active',
+        ];
+    }
+}

--- a/database/migrations/2026_04_13_025603_create_buildings_table.php
+++ b/database/migrations/2026_04_13_025603_create_buildings_table.php
@@ -1,0 +1,42 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('buildings', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('tenant_id')->constrained()->cascadeOnDelete();
+            $table->foreignId('community_id')->constrained()->cascadeOnDelete();
+            $table->string('name', 100);
+            $table->foreignId('city_id')->nullable()->constrained()->nullOnDelete();
+            $table->foreignId('district_id')->nullable()->constrained()->nullOnDelete();
+            $table->unsignedSmallInteger('no_floors')->default(0);
+            $table->year('year_built')->nullable();
+            $table->json('map')->nullable();
+            $table->enum('status', ['active', 'inactive'])->default('active');
+            $table->timestamps();
+            $table->softDeletes();
+
+            // Indexes for efficient tenant-scoped queries
+            $table->index(['tenant_id', 'status']);
+            $table->index(['tenant_id', 'community_id']);
+            $table->index(['community_id', 'status']);
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('buildings');
+    }
+};

--- a/database/migrations/2026_04_13_025937_create_units_table.php
+++ b/database/migrations/2026_04_13_025937_create_units_table.php
@@ -1,0 +1,40 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * Note: This is a minimal schema stub to support Building relationship tests.
+     * Full Unit entity will be implemented in Issue #12.
+     */
+    public function up(): void
+    {
+        Schema::create('units', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('tenant_id')->constrained()->cascadeOnDelete();
+            $table->foreignId('community_id')->constrained()->cascadeOnDelete();
+            $table->foreignId('building_id')->constrained()->cascadeOnDelete();
+            $table->string('name', 100);
+            $table->enum('status', ['active', 'inactive'])->default('active');
+            $table->timestamps();
+            $table->softDeletes();
+
+            // Indexes
+            $table->index(['tenant_id', 'building_id']);
+            $table->index(['building_id', 'status']);
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('units');
+    }
+};

--- a/database/seeders/BuildingSeeder.php
+++ b/database/seeders/BuildingSeeder.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace Database\Seeders;
+
+use Illuminate\Database\Seeder;
+
+class BuildingSeeder extends Seeder
+{
+    /**
+     * Run the database seeds.
+     */
+    public function run(): void
+    {
+        //
+    }
+}

--- a/tests/Feature/BuildingEntityTest.php
+++ b/tests/Feature/BuildingEntityTest.php
@@ -1,0 +1,483 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\Building;
+use App\Models\City;
+use App\Models\Community;
+use App\Models\District;
+use App\Models\Tenant;
+use App\Models\Unit;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class BuildingEntityTest extends TestCase
+{
+    use RefreshDatabase;
+
+    // ==========================================
+    // Model Attribute Tests
+    // ==========================================
+
+    public function test_building_has_correct_fillable_attributes(): void
+    {
+        $tenant = Tenant::factory()->create();
+        $community = Community::factory()->forTenant($tenant)->create();
+        $city = City::factory()->create();
+        $district = District::factory()->create();
+
+        $building = Building::create([
+            'tenant_id' => $tenant->id,
+            'community_id' => $community->id,
+            'name' => 'Test Building',
+            'city_id' => $city->id,
+            'district_id' => $district->id,
+            'no_floors' => 10,
+            'year_built' => 2020,
+            'status' => 'active',
+        ]);
+
+        $this->assertEquals('Test Building', $building->name);
+        $this->assertEquals($tenant->id, $building->tenant_id);
+        $this->assertEquals($community->id, $building->community_id);
+        $this->assertEquals($city->id, $building->city_id);
+        $this->assertEquals($district->id, $building->district_id);
+        $this->assertEquals(10, $building->no_floors);
+        $this->assertEquals(2020, $building->year_built);
+        $this->assertEquals('active', $building->status);
+    }
+
+    public function test_building_casts_integer_attributes(): void
+    {
+        $building = Building::factory()->create([
+            'no_floors' => '15',
+            'year_built' => '2015',
+        ]);
+
+        $this->assertIsInt($building->no_floors);
+        $this->assertIsInt($building->year_built);
+        $this->assertEquals(15, $building->no_floors);
+        $this->assertEquals(2015, $building->year_built);
+    }
+
+    public function test_building_casts_map_as_array(): void
+    {
+        $building = Building::factory()->create([
+            'map' => ['latitude' => 24.7136, 'longitude' => 46.6753],
+        ]);
+
+        $this->assertIsArray($building->map);
+        $this->assertEquals(24.7136, $building->map['latitude']);
+        $this->assertEquals(46.6753, $building->map['longitude']);
+    }
+
+    public function test_building_has_status_constants(): void
+    {
+        $this->assertEquals('active', Building::STATUS_ACTIVE);
+        $this->assertEquals('inactive', Building::STATUS_INACTIVE);
+    }
+
+    public function test_building_statuses_method_returns_all_statuses(): void
+    {
+        $statuses = Building::statuses();
+
+        $this->assertIsArray($statuses);
+        $this->assertCount(2, $statuses);
+        $this->assertContains('active', $statuses);
+        $this->assertContains('inactive', $statuses);
+    }
+
+    // ==========================================
+    // Relationship Tests
+    // ==========================================
+
+    public function test_building_belongs_to_tenant(): void
+    {
+        $tenant = Tenant::factory()->create();
+        $building = Building::factory()->forTenant($tenant)->create();
+
+        $this->assertInstanceOf(Tenant::class, $building->tenant);
+        $this->assertEquals($tenant->id, $building->tenant->id);
+    }
+
+    public function test_building_belongs_to_community(): void
+    {
+        $community = Community::factory()->create();
+        $building = Building::factory()->forCommunity($community)->create();
+
+        $this->assertInstanceOf(Community::class, $building->community);
+        $this->assertEquals($community->id, $building->community->id);
+    }
+
+    public function test_building_belongs_to_city(): void
+    {
+        $city = City::factory()->create();
+        $building = Building::factory()->inCity($city)->create();
+
+        $this->assertInstanceOf(City::class, $building->city);
+        $this->assertEquals($city->id, $building->city->id);
+    }
+
+    public function test_building_belongs_to_district(): void
+    {
+        $district = District::factory()->create();
+        $building = Building::factory()->inDistrict($district)->create();
+
+        $this->assertInstanceOf(District::class, $building->district);
+        $this->assertEquals($district->id, $building->district->id);
+    }
+
+    public function test_building_can_have_null_city_and_district(): void
+    {
+        $building = Building::factory()->create([
+            'city_id' => null,
+            'district_id' => null,
+        ]);
+
+        $this->assertNull($building->city);
+        $this->assertNull($building->district);
+    }
+
+    public function test_building_has_many_units(): void
+    {
+        $building = Building::factory()->create();
+        Unit::factory()->count(3)->create(['building_id' => $building->id]);
+
+        $this->assertCount(3, $building->units);
+        $this->assertInstanceOf(Unit::class, $building->units->first());
+    }
+
+    // ==========================================
+    // Scope Tests
+    // ==========================================
+
+    public function test_building_active_scope(): void
+    {
+        Building::factory()->count(3)->create(['status' => 'active']);
+        Building::factory()->count(2)->create(['status' => 'inactive']);
+
+        $activeBuildings = Building::active()->get();
+
+        $this->assertCount(3, $activeBuildings);
+    }
+
+    public function test_building_inactive_scope(): void
+    {
+        Building::factory()->count(3)->create(['status' => 'active']);
+        Building::factory()->count(2)->create(['status' => 'inactive']);
+
+        $inactiveBuildings = Building::inactive()->get();
+
+        $this->assertCount(2, $inactiveBuildings);
+    }
+
+    public function test_building_for_tenant_scope(): void
+    {
+        $tenant1 = Tenant::factory()->create();
+        $tenant2 = Tenant::factory()->create();
+
+        Building::factory()->count(3)->forTenant($tenant1)->create();
+        Building::factory()->count(2)->forTenant($tenant2)->create();
+
+        $tenant1Buildings = Building::forTenant($tenant1)->get();
+        $tenant2Buildings = Building::forTenant($tenant2->id)->get();
+
+        $this->assertCount(3, $tenant1Buildings);
+        $this->assertCount(2, $tenant2Buildings);
+    }
+
+    public function test_building_for_community_scope(): void
+    {
+        $community1 = Community::factory()->create();
+        $community2 = Community::factory()->create();
+
+        Building::factory()->count(3)->forCommunity($community1)->create();
+        Building::factory()->count(2)->forCommunity($community2)->create();
+
+        $community1Buildings = Building::forCommunity($community1)->get();
+        $community2Buildings = Building::forCommunity($community2->id)->get();
+
+        $this->assertCount(3, $community1Buildings);
+        $this->assertCount(2, $community2Buildings);
+    }
+
+    public function test_building_in_city_scope(): void
+    {
+        $city1 = City::factory()->create();
+        $city2 = City::factory()->create();
+
+        Building::factory()->count(3)->inCity($city1)->create();
+        Building::factory()->count(2)->inCity($city2)->create();
+
+        $city1Buildings = Building::inCity($city1)->get();
+        $city2Buildings = Building::inCity($city2->id)->get();
+
+        $this->assertCount(3, $city1Buildings);
+        $this->assertCount(2, $city2Buildings);
+    }
+
+    public function test_building_in_district_scope(): void
+    {
+        $district1 = District::factory()->create();
+        $district2 = District::factory()->create();
+
+        Building::factory()->count(3)->inDistrict($district1)->create();
+        Building::factory()->count(2)->inDistrict($district2)->create();
+
+        $district1Buildings = Building::inDistrict($district1)->get();
+        $district2Buildings = Building::inDistrict($district2->id)->get();
+
+        $this->assertCount(3, $district1Buildings);
+        $this->assertCount(2, $district2Buildings);
+    }
+
+    // ==========================================
+    // Helper Method Tests
+    // ==========================================
+
+    public function test_building_is_active_method(): void
+    {
+        $activeBuilding = Building::factory()->active()->create();
+        $inactiveBuilding = Building::factory()->inactive()->create();
+
+        $this->assertTrue($activeBuilding->isActive());
+        $this->assertFalse($inactiveBuilding->isActive());
+    }
+
+    public function test_building_is_inactive_method(): void
+    {
+        $activeBuilding = Building::factory()->active()->create();
+        $inactiveBuilding = Building::factory()->inactive()->create();
+
+        $this->assertFalse($activeBuilding->isInactive());
+        $this->assertTrue($inactiveBuilding->isInactive());
+    }
+
+    public function test_building_activate_method(): void
+    {
+        $building = Building::factory()->inactive()->create();
+
+        $this->assertTrue($building->isInactive());
+
+        $building->activate();
+
+        $this->assertTrue($building->isActive());
+    }
+
+    public function test_building_deactivate_method(): void
+    {
+        $building = Building::factory()->active()->create();
+
+        $this->assertTrue($building->isActive());
+
+        $building->deactivate();
+
+        $this->assertTrue($building->isInactive());
+    }
+
+    public function test_building_units_count_attribute(): void
+    {
+        $building = Building::factory()->create();
+        Unit::factory()->count(5)->create(['building_id' => $building->id]);
+
+        $this->assertEquals(5, $building->units_count);
+    }
+
+    // ==========================================
+    // Soft Delete Tests
+    // ==========================================
+
+    public function test_building_uses_soft_deletes(): void
+    {
+        $building = Building::factory()->create();
+
+        $building->delete();
+
+        $this->assertSoftDeleted('buildings', ['id' => $building->id]);
+        $this->assertNull(Building::find($building->id));
+        $this->assertNotNull(Building::withTrashed()->find($building->id));
+    }
+
+    public function test_building_can_be_restored(): void
+    {
+        $building = Building::factory()->create();
+        $building->delete();
+
+        $this->assertSoftDeleted('buildings', ['id' => $building->id]);
+
+        $building->restore();
+
+        $this->assertNotSoftDeleted('buildings', ['id' => $building->id]);
+        $this->assertNotNull(Building::find($building->id));
+    }
+
+    // ==========================================
+    // Factory State Tests
+    // ==========================================
+
+    public function test_factory_creates_valid_building(): void
+    {
+        $building = Building::factory()->create();
+
+        $this->assertNotNull($building->id);
+        $this->assertNotEmpty($building->name);
+        $this->assertNotNull($building->tenant_id);
+        $this->assertNotNull($building->community_id);
+        $this->assertEquals('active', $building->status);
+    }
+
+    public function test_factory_active_state(): void
+    {
+        $building = Building::factory()->active()->create();
+
+        $this->assertEquals('active', $building->status);
+    }
+
+    public function test_factory_inactive_state(): void
+    {
+        $building = Building::factory()->inactive()->create();
+
+        $this->assertEquals('inactive', $building->status);
+    }
+
+    public function test_factory_for_tenant_state(): void
+    {
+        $tenant = Tenant::factory()->create();
+        $building = Building::factory()->forTenant($tenant)->create();
+
+        $this->assertEquals($tenant->id, $building->tenant_id);
+    }
+
+    public function test_factory_for_community_state(): void
+    {
+        $community = Community::factory()->create();
+        $building = Building::factory()->forCommunity($community)->create();
+
+        $this->assertEquals($community->id, $building->community_id);
+        $this->assertEquals($community->tenant_id, $building->tenant_id);
+    }
+
+    public function test_factory_in_city_state(): void
+    {
+        $city = City::factory()->create();
+        $building = Building::factory()->inCity($city)->create();
+
+        $this->assertEquals($city->id, $building->city_id);
+    }
+
+    public function test_factory_in_district_state(): void
+    {
+        $district = District::factory()->create();
+        $building = Building::factory()->inDistrict($district)->create();
+
+        $this->assertEquals($district->id, $building->district_id);
+    }
+
+    public function test_factory_with_floors_state(): void
+    {
+        $building = Building::factory()->withFloors(25)->create();
+
+        $this->assertEquals(25, $building->no_floors);
+    }
+
+    public function test_factory_built_in_state(): void
+    {
+        $building = Building::factory()->builtIn(2018)->create();
+
+        $this->assertEquals(2018, $building->year_built);
+    }
+
+    public function test_factory_with_map_state(): void
+    {
+        $building = Building::factory()->withMap(24.7136, 46.6753)->create();
+
+        $this->assertEquals(24.7136, $building->map['latitude']);
+        $this->assertEquals(46.6753, $building->map['longitude']);
+    }
+
+    public function test_factory_tower_state(): void
+    {
+        $building = Building::factory()->tower()->create();
+
+        $this->assertStringContainsString('Tower', $building->name);
+        $this->assertGreaterThanOrEqual(20, $building->no_floors);
+    }
+
+    public function test_factory_villa_state(): void
+    {
+        $building = Building::factory()->villa()->create();
+
+        $this->assertStringContainsString('Villa', $building->name);
+        $this->assertLessThanOrEqual(3, $building->no_floors);
+    }
+
+    // ==========================================
+    // Multi-tenant Isolation Tests
+    // ==========================================
+
+    public function test_buildings_are_tenant_isolated(): void
+    {
+        $tenant1 = Tenant::factory()->create();
+        $tenant2 = Tenant::factory()->create();
+
+        $building1 = Building::factory()->forTenant($tenant1)->create(['name' => 'Tenant 1 Building']);
+        $building2 = Building::factory()->forTenant($tenant2)->create(['name' => 'Tenant 2 Building']);
+
+        $tenant1Buildings = Building::forTenant($tenant1)->get();
+        $tenant2Buildings = Building::forTenant($tenant2)->get();
+
+        $this->assertCount(1, $tenant1Buildings);
+        $this->assertCount(1, $tenant2Buildings);
+        $this->assertEquals('Tenant 1 Building', $tenant1Buildings->first()->name);
+        $this->assertEquals('Tenant 2 Building', $tenant2Buildings->first()->name);
+    }
+
+    // ==========================================
+    // Property Hierarchy Tests
+    // ==========================================
+
+    public function test_building_belongs_to_community_hierarchy(): void
+    {
+        $tenant = Tenant::factory()->create();
+        $community = Community::factory()->forTenant($tenant)->create();
+        $building = Building::factory()->forCommunity($community)->create();
+
+        $this->assertEquals($community->id, $building->community_id);
+        $this->assertEquals($tenant->id, $building->tenant_id);
+        $this->assertInstanceOf(Community::class, $building->community);
+        $this->assertInstanceOf(Tenant::class, $building->community->tenant);
+        $this->assertEquals($tenant->id, $building->community->tenant->id);
+    }
+
+    public function test_community_has_many_buildings(): void
+    {
+        $community = Community::factory()->create();
+        Building::factory()->count(3)->forCommunity($community)->create();
+
+        $this->assertCount(3, $community->buildings);
+    }
+
+    // ==========================================
+    // Cascade Delete Tests
+    // ==========================================
+
+    public function test_building_is_deleted_when_community_is_deleted(): void
+    {
+        $community = Community::factory()->create();
+        $building = Building::factory()->forCommunity($community)->create();
+
+        $community->forceDelete();
+
+        $this->assertDatabaseMissing('buildings', ['id' => $building->id]);
+    }
+
+    public function test_building_is_deleted_when_tenant_is_deleted(): void
+    {
+        $tenant = Tenant::factory()->create();
+        $building = Building::factory()->forTenant($tenant)->create();
+
+        $tenant->forceDelete();
+
+        $this->assertDatabaseMissing('buildings', ['id' => $building->id]);
+    }
+}


### PR DESCRIPTION
## Summary
- Implements the Buildings Entity as the second level in the property hierarchy
- Property hierarchy: Community → Building → Unit
- Full multi-tenant support with tenant_id foreign key
- Proper relationship with parent Community

## Changes
- **Migration**: Creates `buildings` table with all fields per PRD specification:
  - Multi-tenant support (tenant_id with cascade delete)
  - Community relationship (community_id with cascade delete)
  - Location fields (city_id, district_id - optional)
  - Building attributes (no_floors, year_built)
  - Map JSON field for coordinates
  - Status enum (active/inactive)
  - Proper indexes for tenant-scoped queries
- **Building Model**: Full implementation with:
  - Status constants (STATUS_ACTIVE, STATUS_INACTIVE)
  - Relationships: tenant, community, city, district, units
  - Scopes: active, inactive, forTenant, forCommunity, inCity, inDistrict
  - Helper methods: isActive, isInactive, activate, deactivate, statuses
  - Computed attribute: units_count
  - Soft deletes support
- **BuildingFactory**: 11 factory states for testing:
  - active, inactive, forTenant, forCommunity
  - inCity, inDistrict, withFloors, builtIn, withMap
  - tower (high-rise), villa (low-rise)
- **Unit Model Stub**: Minimal implementation to support Building relationship tests
- **UnitFactory Stub**: Minimal factory for Building tests
- **Tests**: 41 tests with 92 assertions covering:
  - Model attributes and fillables
  - Integer casts (no_floors, year_built)
  - Map JSON cast
  - All relationships (tenant, community, city, district, units)
  - All scopes (active, inactive, forTenant, forCommunity, inCity, inDistrict)
  - Helper methods (isActive, isInactive, activate, deactivate)
  - Computed attribute (units_count)
  - Soft delete functionality
  - Factory states (11 states tested)
  - Multi-tenant isolation
  - Property hierarchy tests
  - Cascade delete behavior

## Notes
- Unit model and factory are stubs with minimal implementation
- Full Unit entity will be implemented in Issue #12

## Test Plan
- [x] Run `php artisan test --compact tests/Feature/BuildingEntityTest.php`
- [x] All 41 tests pass (92 assertions)
- [x] Code formatted with Pint

Closes #11

🤖 Generated with [Claude Code](https://claude.com/claude-code)