### PR TITLE
Issue #12: Units Entity

### DIFF
--- a/app/Models/Unit.php
+++ b/app/Models/Unit.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\Models;
 
 use Database\Factories\UnitFactory;
+use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
@@ -16,8 +17,8 @@ use Illuminate\Database\Eloquent\SoftDeletes;
  * Units are the third level in the property hierarchy:
  * Community → Building → Unit
  *
- * Note: This is a minimal stub to support Building relationship tests.
- * Full Unit entity will be implemented in Issue #12.
+ * Units can be apartments, offices, retail spaces, or any
+ * rentable/sellable space within a property.
  */
 class Unit extends Model
 {
@@ -33,9 +34,41 @@ class Unit extends Model
         'tenant_id',
         'community_id',
         'building_id',
+        'unit_category_id',
+        'unit_type_id',
+        'status_id',
+        'city_id',
+        'district_id',
         'name',
-        'status',
+        'floor_no',
+        'net_area',
+        'year_built',
+        'market_rent',
+        'about',
+        'map',
+        'photos',
+        'is_marketplace',
+        'is_off_plan_sale',
     ];
+
+    /**
+     * Get the attributes that should be cast.
+     *
+     * @return array<string, string>
+     */
+    protected function casts(): array
+    {
+        return [
+            'floor_no' => 'integer',
+            'net_area' => 'decimal:2',
+            'year_built' => 'integer',
+            'market_rent' => 'decimal:2',
+            'map' => 'array',
+            'photos' => 'array',
+            'is_marketplace' => 'boolean',
+            'is_off_plan_sale' => 'boolean',
+        ];
+    }
 
     // ==========================================
     // Relationships
@@ -63,5 +96,287 @@ class Unit extends Model
     public function building(): BelongsTo
     {
         return $this->belongsTo(Building::class);
+    }
+
+    /**
+     * Get the unit category.
+     */
+    public function category(): BelongsTo
+    {
+        return $this->belongsTo(UnitCategory::class, 'unit_category_id');
+    }
+
+    /**
+     * Get the unit type.
+     */
+    public function type(): BelongsTo
+    {
+        return $this->belongsTo(UnitType::class, 'unit_type_id');
+    }
+
+    /**
+     * Get the unit status.
+     */
+    public function status(): BelongsTo
+    {
+        return $this->belongsTo(Status::class);
+    }
+
+    /**
+     * Get the city where this unit is located.
+     */
+    public function city(): BelongsTo
+    {
+        return $this->belongsTo(City::class);
+    }
+
+    /**
+     * Get the district where this unit is located.
+     */
+    public function district(): BelongsTo
+    {
+        return $this->belongsTo(District::class);
+    }
+
+    // ==========================================
+    // Scopes
+    // ==========================================
+
+    /**
+     * Scope to filter units for a specific tenant.
+     */
+    public function scopeForTenant(Builder $query, Tenant|int $tenant): Builder
+    {
+        $tenantId = $tenant instanceof Tenant ? $tenant->id : $tenant;
+
+        return $query->where('tenant_id', $tenantId);
+    }
+
+    /**
+     * Scope to filter units for a specific community.
+     */
+    public function scopeForCommunity(Builder $query, Community|int $community): Builder
+    {
+        $communityId = $community instanceof Community ? $community->id : $community;
+
+        return $query->where('community_id', $communityId);
+    }
+
+    /**
+     * Scope to filter units for a specific building.
+     */
+    public function scopeForBuilding(Builder $query, Building|int $building): Builder
+    {
+        $buildingId = $building instanceof Building ? $building->id : $building;
+
+        return $query->where('building_id', $buildingId);
+    }
+
+    /**
+     * Scope to filter units by category.
+     */
+    public function scopeForCategory(Builder $query, UnitCategory|int $category): Builder
+    {
+        $categoryId = $category instanceof UnitCategory ? $category->id : $category;
+
+        return $query->where('unit_category_id', $categoryId);
+    }
+
+    /**
+     * Scope to filter units by type.
+     */
+    public function scopeForType(Builder $query, UnitType|int $type): Builder
+    {
+        $typeId = $type instanceof UnitType ? $type->id : $type;
+
+        return $query->where('unit_type_id', $typeId);
+    }
+
+    /**
+     * Scope to filter units by status.
+     */
+    public function scopeWithStatus(Builder $query, Status|int $status): Builder
+    {
+        $statusId = $status instanceof Status ? $status->id : $status;
+
+        return $query->where('status_id', $statusId);
+    }
+
+    /**
+     * Scope to filter units in a specific city.
+     */
+    public function scopeInCity(Builder $query, City|int $city): Builder
+    {
+        $cityId = $city instanceof City ? $city->id : $city;
+
+        return $query->where('city_id', $cityId);
+    }
+
+    /**
+     * Scope to filter units in a specific district.
+     */
+    public function scopeInDistrict(Builder $query, District|int $district): Builder
+    {
+        $districtId = $district instanceof District ? $district->id : $district;
+
+        return $query->where('district_id', $districtId);
+    }
+
+    /**
+     * Scope to filter marketplace units.
+     */
+    public function scopeMarketplace(Builder $query): Builder
+    {
+        return $query->where('is_marketplace', true);
+    }
+
+    /**
+     * Scope to filter non-marketplace units.
+     */
+    public function scopeNotMarketplace(Builder $query): Builder
+    {
+        return $query->where('is_marketplace', false);
+    }
+
+    /**
+     * Scope to filter off-plan sale units.
+     */
+    public function scopeOffPlanSale(Builder $query): Builder
+    {
+        return $query->where('is_off_plan_sale', true);
+    }
+
+    /**
+     * Scope to filter units on a specific floor.
+     */
+    public function scopeOnFloor(Builder $query, int $floor): Builder
+    {
+        return $query->where('floor_no', $floor);
+    }
+
+    /**
+     * Scope to filter units by minimum area.
+     */
+    public function scopeMinArea(Builder $query, float $minArea): Builder
+    {
+        return $query->where('net_area', '>=', $minArea);
+    }
+
+    /**
+     * Scope to filter units by maximum area.
+     */
+    public function scopeMaxArea(Builder $query, float $maxArea): Builder
+    {
+        return $query->where('net_area', '<=', $maxArea);
+    }
+
+    /**
+     * Scope to filter units by area range.
+     */
+    public function scopeAreaBetween(Builder $query, float $minArea, float $maxArea): Builder
+    {
+        return $query->whereBetween('net_area', [$minArea, $maxArea]);
+    }
+
+    /**
+     * Scope to filter units by minimum rent.
+     */
+    public function scopeMinRent(Builder $query, float $minRent): Builder
+    {
+        return $query->where('market_rent', '>=', $minRent);
+    }
+
+    /**
+     * Scope to filter units by maximum rent.
+     */
+    public function scopeMaxRent(Builder $query, float $maxRent): Builder
+    {
+        return $query->where('market_rent', '<=', $maxRent);
+    }
+
+    /**
+     * Scope to filter units by rent range.
+     */
+    public function scopeRentBetween(Builder $query, float $minRent, float $maxRent): Builder
+    {
+        return $query->whereBetween('market_rent', [$minRent, $maxRent]);
+    }
+
+    // ==========================================
+    // Helper Methods
+    // ==========================================
+
+    /**
+     * Check if the unit is listed on marketplace.
+     */
+    public function isOnMarketplace(): bool
+    {
+        return $this->is_marketplace === true;
+    }
+
+    /**
+     * Check if the unit is for off-plan sale.
+     */
+    public function isOffPlanSale(): bool
+    {
+        return $this->is_off_plan_sale === true;
+    }
+
+    /**
+     * List the unit on marketplace.
+     */
+    public function listOnMarketplace(): bool
+    {
+        return $this->update(['is_marketplace' => true]);
+    }
+
+    /**
+     * Remove the unit from marketplace.
+     */
+    public function removeFromMarketplace(): bool
+    {
+        return $this->update(['is_marketplace' => false]);
+    }
+
+    /**
+     * Get the full address including building and community.
+     */
+    public function getFullAddressAttribute(): string
+    {
+        $parts = [$this->name];
+
+        if ($this->building) {
+            $parts[] = $this->building->name;
+        }
+
+        if ($this->community) {
+            $parts[] = $this->community->name;
+        }
+
+        return implode(', ', $parts);
+    }
+
+    /**
+     * Check if the unit has photos.
+     */
+    public function hasPhotos(): bool
+    {
+        return ! empty($this->photos);
+    }
+
+    /**
+     * Get the photo count.
+     */
+    public function getPhotoCountAttribute(): int
+    {
+        return is_array($this->photos) ? count($this->photos) : 0;
+    }
+
+    /**
+     * Check if the unit has map coordinates.
+     */
+    public function hasMapCoordinates(): bool
+    {
+        return ! empty($this->map) && isset($this->map['latitude']) && isset($this->map['longitude']);
     }
 }

--- a/database/factories/UnitCategoryFactory.php
+++ b/database/factories/UnitCategoryFactory.php
@@ -17,10 +17,10 @@ class UnitCategoryFactory extends Factory
      */
     public function definition(): array
     {
-        $categories = ['Residential', 'Commercial', 'Industrial', 'Mixed Use', 'Retail', 'Office'];
+        $categories = ['Residential', 'Commercial', 'Industrial', 'Mixed Use', 'Retail', 'Office', 'Warehouse', 'Storage', 'Hospitality', 'Healthcare'];
 
         return [
-            'name' => fake()->unique()->randomElement($categories),
+            'name' => fake()->randomElement($categories).' '.fake()->numberBetween(1, 9999),
             'name_ar' => null,
             'description' => fake()->sentence(),
             'is_active' => true,

--- a/database/factories/UnitFactory.php
+++ b/database/factories/UnitFactory.php
@@ -3,16 +3,18 @@
 namespace Database\Factories;
 
 use App\Models\Building;
+use App\Models\City;
 use App\Models\Community;
+use App\Models\District;
+use App\Models\Status;
 use App\Models\Tenant;
 use App\Models\Unit;
+use App\Models\UnitCategory;
+use App\Models\UnitType;
 use Illuminate\Database\Eloquent\Factories\Factory;
 
 /**
  * @extends Factory<Unit>
- *
- * Note: This is a minimal factory stub to support Building relationship tests.
- * Full Unit factory will be implemented in Issue #12.
  */
 class UnitFactory extends Factory
 {
@@ -27,8 +29,260 @@ class UnitFactory extends Factory
             'tenant_id' => Tenant::factory(),
             'community_id' => Community::factory(),
             'building_id' => Building::factory(),
+            'unit_category_id' => UnitCategory::factory(),
+            'unit_type_id' => UnitType::factory(),
+            'status_id' => null,
+            'city_id' => null,
+            'district_id' => null,
             'name' => 'Unit '.fake()->numberBetween(100, 9999),
-            'status' => 'active',
+            'floor_no' => fake()->numberBetween(1, 50),
+            'net_area' => fake()->randomFloat(2, 50, 500),
+            'year_built' => fake()->optional(0.7)->numberBetween(1990, 2025),
+            'market_rent' => fake()->randomFloat(2, 1000, 50000),
+            'about' => fake()->optional(0.5)->paragraph(),
+            'map' => null,
+            'photos' => null,
+            'is_marketplace' => false,
+            'is_off_plan_sale' => false,
         ];
+    }
+
+    /**
+     * Set the unit for a specific tenant.
+     */
+    public function forTenant(Tenant $tenant): static
+    {
+        return $this->state(fn (array $attributes) => [
+            'tenant_id' => $tenant->id,
+        ]);
+    }
+
+    /**
+     * Set the unit for a specific community.
+     */
+    public function forCommunity(Community $community): static
+    {
+        return $this->state(fn (array $attributes) => [
+            'community_id' => $community->id,
+            'tenant_id' => $community->tenant_id,
+        ]);
+    }
+
+    /**
+     * Set the unit for a specific building.
+     */
+    public function forBuilding(Building $building): static
+    {
+        return $this->state(fn (array $attributes) => [
+            'building_id' => $building->id,
+            'community_id' => $building->community_id,
+            'tenant_id' => $building->tenant_id,
+        ]);
+    }
+
+    /**
+     * Set the unit category.
+     */
+    public function withCategory(UnitCategory $category): static
+    {
+        return $this->state(fn (array $attributes) => [
+            'unit_category_id' => $category->id,
+        ]);
+    }
+
+    /**
+     * Set the unit type.
+     */
+    public function withType(UnitType $type): static
+    {
+        return $this->state(fn (array $attributes) => [
+            'unit_type_id' => $type->id,
+        ]);
+    }
+
+    /**
+     * Set the unit status.
+     */
+    public function withStatus(Status $status): static
+    {
+        return $this->state(fn (array $attributes) => [
+            'status_id' => $status->id,
+        ]);
+    }
+
+    /**
+     * Set the unit in a specific city.
+     */
+    public function inCity(City $city): static
+    {
+        return $this->state(fn (array $attributes) => [
+            'city_id' => $city->id,
+        ]);
+    }
+
+    /**
+     * Set the unit in a specific district.
+     */
+    public function inDistrict(District $district): static
+    {
+        return $this->state(fn (array $attributes) => [
+            'district_id' => $district->id,
+        ]);
+    }
+
+    /**
+     * Set the floor number.
+     */
+    public function onFloor(int $floor): static
+    {
+        return $this->state(fn (array $attributes) => [
+            'floor_no' => $floor,
+        ]);
+    }
+
+    /**
+     * Set the net area.
+     */
+    public function withArea(float $area): static
+    {
+        return $this->state(fn (array $attributes) => [
+            'net_area' => $area,
+        ]);
+    }
+
+    /**
+     * Set the market rent.
+     */
+    public function withRent(float $rent): static
+    {
+        return $this->state(fn (array $attributes) => [
+            'market_rent' => $rent,
+        ]);
+    }
+
+    /**
+     * Set the year built.
+     */
+    public function builtIn(int $year): static
+    {
+        return $this->state(fn (array $attributes) => [
+            'year_built' => $year,
+        ]);
+    }
+
+    /**
+     * Set map coordinates.
+     */
+    public function withMap(float $latitude, float $longitude): static
+    {
+        return $this->state(fn (array $attributes) => [
+            'map' => [
+                'latitude' => $latitude,
+                'longitude' => $longitude,
+            ],
+        ]);
+    }
+
+    /**
+     * Set photos.
+     *
+     * @param  array<string>  $photos
+     */
+    public function withPhotos(array $photos): static
+    {
+        return $this->state(fn (array $attributes) => [
+            'photos' => $photos,
+        ]);
+    }
+
+    /**
+     * List the unit on marketplace.
+     */
+    public function marketplace(): static
+    {
+        return $this->state(fn (array $attributes) => [
+            'is_marketplace' => true,
+        ]);
+    }
+
+    /**
+     * Mark the unit as off-plan sale.
+     */
+    public function offPlanSale(): static
+    {
+        return $this->state(fn (array $attributes) => [
+            'is_off_plan_sale' => true,
+        ]);
+    }
+
+    /**
+     * Create a studio apartment.
+     */
+    public function studio(): static
+    {
+        return $this->state(fn (array $attributes) => [
+            'name' => 'Studio '.fake()->numberBetween(100, 999),
+            'net_area' => fake()->randomFloat(2, 25, 50),
+            'floor_no' => fake()->numberBetween(1, 20),
+        ]);
+    }
+
+    /**
+     * Create a penthouse unit.
+     */
+    public function penthouse(): static
+    {
+        return $this->state(fn (array $attributes) => [
+            'name' => 'Penthouse '.fake()->numberBetween(1, 99),
+            'net_area' => fake()->randomFloat(2, 200, 600),
+            'floor_no' => fake()->numberBetween(30, 100),
+            'market_rent' => fake()->randomFloat(2, 20000, 100000),
+        ]);
+    }
+
+    /**
+     * Create a villa unit.
+     */
+    public function villa(): static
+    {
+        return $this->state(fn (array $attributes) => [
+            'name' => 'Villa '.fake()->numberBetween(1, 999),
+            'net_area' => fake()->randomFloat(2, 300, 1000),
+            'floor_no' => 1,
+            'market_rent' => fake()->randomFloat(2, 15000, 80000),
+        ]);
+    }
+
+    /**
+     * Create a commercial unit (retail/office).
+     */
+    public function commercial(): static
+    {
+        return $this->state(fn (array $attributes) => [
+            'name' => 'Shop '.fake()->numberBetween(1, 100),
+            'net_area' => fake()->randomFloat(2, 30, 200),
+            'floor_no' => fake()->numberBetween(0, 3),
+            'market_rent' => fake()->randomFloat(2, 5000, 30000),
+        ]);
+    }
+
+    /**
+     * Create a unit without a building (standalone community unit).
+     */
+    public function withoutBuilding(): static
+    {
+        return $this->state(fn (array $attributes) => [
+            'building_id' => null,
+        ]);
+    }
+
+    /**
+     * Create a unit with description.
+     */
+    public function withDescription(string $description): static
+    {
+        return $this->state(fn (array $attributes) => [
+            'about' => $description,
+        ]);
     }
 }

--- a/database/factories/UnitTypeFactory.php
+++ b/database/factories/UnitTypeFactory.php
@@ -18,11 +18,11 @@ class UnitTypeFactory extends Factory
      */
     public function definition(): array
     {
-        $types = ['Studio', 'Apartment', 'Villa', 'Townhouse', 'Penthouse', 'Duplex', 'Loft'];
+        $types = ['Studio', 'Apartment', 'Villa', 'Townhouse', 'Penthouse', 'Duplex', 'Loft', 'Maisonette', 'Flat', 'Suite'];
 
         return [
             'unit_category_id' => UnitCategory::factory(),
-            'name' => fake()->unique()->randomElement($types),
+            'name' => fake()->randomElement($types).' '.fake()->numberBetween(1, 9999),
             'name_ar' => null,
             'description' => fake()->sentence(),
             'is_active' => true,

--- a/database/migrations/2026_04_13_025937_create_units_table.php
+++ b/database/migrations/2026_04_13_025937_create_units_table.php
@@ -8,9 +8,6 @@ return new class extends Migration
 {
     /**
      * Run the migrations.
-     *
-     * Note: This is a minimal schema stub to support Building relationship tests.
-     * Full Unit entity will be implemented in Issue #12.
      */
     public function up(): void
     {
@@ -18,15 +15,42 @@ return new class extends Migration
             $table->id();
             $table->foreignId('tenant_id')->constrained()->cascadeOnDelete();
             $table->foreignId('community_id')->constrained()->cascadeOnDelete();
-            $table->foreignId('building_id')->constrained()->cascadeOnDelete();
+            $table->foreignId('building_id')->nullable()->constrained()->nullOnDelete();
+            $table->foreignId('unit_category_id')->constrained()->cascadeOnDelete();
+            $table->foreignId('unit_type_id')->constrained()->cascadeOnDelete();
+            $table->foreignId('status_id')->nullable()->constrained('statuses')->nullOnDelete();
+            $table->foreignId('city_id')->nullable()->constrained()->nullOnDelete();
+            $table->foreignId('district_id')->nullable()->constrained()->nullOnDelete();
+
+            // Basic unit information
             $table->string('name', 100);
-            $table->enum('status', ['active', 'inactive'])->default('active');
+            $table->unsignedSmallInteger('floor_no')->nullable();
+            $table->decimal('net_area', 12, 2)->nullable();
+            $table->year('year_built')->nullable();
+            $table->decimal('market_rent', 12, 2)->nullable();
+            $table->text('about')->nullable();
+
+            // Location data
+            $table->json('map')->nullable();
+
+            // Media (stored as JSON arrays of URLs/paths)
+            $table->json('photos')->nullable();
+
+            // Marketplace flags
+            $table->boolean('is_marketplace')->default(false);
+            $table->boolean('is_off_plan_sale')->default(false);
+
             $table->timestamps();
             $table->softDeletes();
 
-            // Indexes
+            // Indexes for efficient tenant-scoped queries
+            $table->index(['tenant_id', 'community_id']);
             $table->index(['tenant_id', 'building_id']);
-            $table->index(['building_id', 'status']);
+            $table->index(['tenant_id', 'status_id']);
+            $table->index(['community_id', 'building_id']);
+            $table->index(['building_id', 'status_id']);
+            $table->index(['unit_category_id', 'unit_type_id']);
+            $table->index('is_marketplace');
         });
     }
 

--- a/tests/Feature/UnitEntityTest.php
+++ b/tests/Feature/UnitEntityTest.php
@@ -1,0 +1,677 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\Building;
+use App\Models\City;
+use App\Models\Community;
+use App\Models\District;
+use App\Models\Status;
+use App\Models\Tenant;
+use App\Models\Unit;
+use App\Models\UnitCategory;
+use App\Models\UnitType;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class UnitEntityTest extends TestCase
+{
+    use RefreshDatabase;
+
+    // ==========================================
+    // Basic Model Tests
+    // ==========================================
+
+    public function test_unit_can_be_created_with_factory(): void
+    {
+        $unit = Unit::factory()->create();
+
+        $this->assertDatabaseHas('units', [
+            'id' => $unit->id,
+            'name' => $unit->name,
+        ]);
+    }
+
+    public function test_unit_has_required_attributes(): void
+    {
+        $unit = Unit::factory()->create([
+            'name' => 'Unit 101',
+            'floor_no' => 5,
+            'net_area' => 150.50,
+            'market_rent' => 5000.00,
+        ]);
+
+        $this->assertEquals('Unit 101', $unit->name);
+        $this->assertEquals(5, $unit->floor_no);
+        $this->assertEquals(150.50, $unit->net_area);
+        $this->assertEquals(5000.00, $unit->market_rent);
+    }
+
+    public function test_unit_has_fillable_attributes(): void
+    {
+        $unit = new Unit;
+        $fillable = $unit->getFillable();
+
+        $this->assertContains('tenant_id', $fillable);
+        $this->assertContains('community_id', $fillable);
+        $this->assertContains('building_id', $fillable);
+        $this->assertContains('unit_category_id', $fillable);
+        $this->assertContains('unit_type_id', $fillable);
+        $this->assertContains('status_id', $fillable);
+        $this->assertContains('name', $fillable);
+        $this->assertContains('floor_no', $fillable);
+        $this->assertContains('net_area', $fillable);
+        $this->assertContains('market_rent', $fillable);
+        $this->assertContains('is_marketplace', $fillable);
+        $this->assertContains('is_off_plan_sale', $fillable);
+    }
+
+    public function test_unit_casts_attributes_correctly(): void
+    {
+        $unit = Unit::factory()->create([
+            'floor_no' => '10',
+            'net_area' => '200.50',
+            'year_built' => '2020',
+            'market_rent' => '15000.75',
+            'is_marketplace' => 1,
+            'is_off_plan_sale' => 0,
+            'map' => ['latitude' => 25.2048, 'longitude' => 55.2708],
+            'photos' => ['photo1.jpg', 'photo2.jpg'],
+        ]);
+
+        $this->assertIsInt($unit->floor_no);
+        $this->assertIsString($unit->net_area); // decimal cast returns string
+        $this->assertIsInt($unit->year_built);
+        $this->assertIsString($unit->market_rent); // decimal cast returns string
+        $this->assertIsBool($unit->is_marketplace);
+        $this->assertIsBool($unit->is_off_plan_sale);
+        $this->assertIsArray($unit->map);
+        $this->assertIsArray($unit->photos);
+    }
+
+    public function test_unit_uses_soft_deletes(): void
+    {
+        $unit = Unit::factory()->create();
+        $unitId = $unit->id;
+
+        $unit->delete();
+
+        $this->assertSoftDeleted('units', ['id' => $unitId]);
+        $this->assertNotNull(Unit::withTrashed()->find($unitId));
+    }
+
+    public function test_deleted_unit_can_be_restored(): void
+    {
+        $unit = Unit::factory()->create();
+        $unit->delete();
+
+        $unit->restore();
+
+        $this->assertDatabaseHas('units', [
+            'id' => $unit->id,
+            'deleted_at' => null,
+        ]);
+    }
+
+    // ==========================================
+    // Relationship Tests
+    // ==========================================
+
+    public function test_unit_belongs_to_tenant(): void
+    {
+        $tenant = Tenant::factory()->create();
+        $unit = Unit::factory()->forTenant($tenant)->create();
+
+        $this->assertTrue($unit->tenant->is($tenant));
+        $this->assertInstanceOf(Tenant::class, $unit->tenant);
+    }
+
+    public function test_unit_belongs_to_community(): void
+    {
+        $community = Community::factory()->create();
+        $unit = Unit::factory()->forCommunity($community)->create();
+
+        $this->assertTrue($unit->community->is($community));
+        $this->assertInstanceOf(Community::class, $unit->community);
+    }
+
+    public function test_unit_belongs_to_building(): void
+    {
+        $building = Building::factory()->create();
+        $unit = Unit::factory()->forBuilding($building)->create();
+
+        $this->assertTrue($unit->building->is($building));
+        $this->assertInstanceOf(Building::class, $unit->building);
+    }
+
+    public function test_unit_can_exist_without_building(): void
+    {
+        $unit = Unit::factory()->withoutBuilding()->create();
+
+        $this->assertNull($unit->building_id);
+        $this->assertNull($unit->building);
+    }
+
+    public function test_unit_belongs_to_category(): void
+    {
+        $category = UnitCategory::factory()->create();
+        $unit = Unit::factory()->withCategory($category)->create();
+
+        $this->assertTrue($unit->category->is($category));
+        $this->assertInstanceOf(UnitCategory::class, $unit->category);
+    }
+
+    public function test_unit_belongs_to_type(): void
+    {
+        $type = UnitType::factory()->create();
+        $unit = Unit::factory()->withType($type)->create();
+
+        $this->assertTrue($unit->type->is($type));
+        $this->assertInstanceOf(UnitType::class, $unit->type);
+    }
+
+    public function test_unit_belongs_to_status(): void
+    {
+        $status = Status::factory()->forDomain(Status::DOMAIN_UNIT)->create();
+        $unit = Unit::factory()->withStatus($status)->create();
+
+        $this->assertTrue($unit->status->is($status));
+        $this->assertInstanceOf(Status::class, $unit->status);
+    }
+
+    public function test_unit_can_exist_without_status(): void
+    {
+        $unit = Unit::factory()->create(['status_id' => null]);
+
+        $this->assertNull($unit->status_id);
+        $this->assertNull($unit->status);
+    }
+
+    public function test_unit_belongs_to_city(): void
+    {
+        $city = City::factory()->create();
+        $unit = Unit::factory()->inCity($city)->create();
+
+        $this->assertTrue($unit->city->is($city));
+        $this->assertInstanceOf(City::class, $unit->city);
+    }
+
+    public function test_unit_belongs_to_district(): void
+    {
+        $district = District::factory()->create();
+        $unit = Unit::factory()->inDistrict($district)->create();
+
+        $this->assertTrue($unit->district->is($district));
+        $this->assertInstanceOf(District::class, $unit->district);
+    }
+
+    // ==========================================
+    // Scope Tests
+    // ==========================================
+
+    public function test_scope_for_tenant_filters_correctly(): void
+    {
+        $tenant1 = Tenant::factory()->create();
+        $tenant2 = Tenant::factory()->create();
+
+        Unit::factory()->count(3)->forTenant($tenant1)->create();
+        Unit::factory()->count(2)->forTenant($tenant2)->create();
+
+        $units = Unit::forTenant($tenant1)->get();
+
+        $this->assertCount(3, $units);
+        $units->each(fn ($unit) => $this->assertEquals($tenant1->id, $unit->tenant_id));
+    }
+
+    public function test_scope_for_community_filters_correctly(): void
+    {
+        $community1 = Community::factory()->create();
+        $community2 = Community::factory()->create();
+
+        Unit::factory()->count(2)->forCommunity($community1)->create();
+        Unit::factory()->count(4)->forCommunity($community2)->create();
+
+        $units = Unit::forCommunity($community1)->get();
+
+        $this->assertCount(2, $units);
+        $units->each(fn ($unit) => $this->assertEquals($community1->id, $unit->community_id));
+    }
+
+    public function test_scope_for_building_filters_correctly(): void
+    {
+        $building1 = Building::factory()->create();
+        $building2 = Building::factory()->create();
+
+        Unit::factory()->count(5)->forBuilding($building1)->create();
+        Unit::factory()->count(3)->forBuilding($building2)->create();
+
+        $units = Unit::forBuilding($building1)->get();
+
+        $this->assertCount(5, $units);
+        $units->each(fn ($unit) => $this->assertEquals($building1->id, $unit->building_id));
+    }
+
+    public function test_scope_for_category_filters_correctly(): void
+    {
+        $category = UnitCategory::factory()->create();
+        Unit::factory()->count(3)->withCategory($category)->create();
+        Unit::factory()->count(2)->create(); // Different category
+
+        $units = Unit::forCategory($category)->get();
+
+        $this->assertCount(3, $units);
+    }
+
+    public function test_scope_for_type_filters_correctly(): void
+    {
+        $type = UnitType::factory()->create();
+        Unit::factory()->count(4)->withType($type)->create();
+        Unit::factory()->count(2)->create(); // Different type
+
+        $units = Unit::forType($type)->get();
+
+        $this->assertCount(4, $units);
+    }
+
+    public function test_scope_with_status_filters_correctly(): void
+    {
+        $status = Status::factory()->forDomain(Status::DOMAIN_UNIT)->create();
+        Unit::factory()->count(2)->withStatus($status)->create();
+        Unit::factory()->count(3)->create(); // No status
+
+        $units = Unit::withStatus($status)->get();
+
+        $this->assertCount(2, $units);
+    }
+
+    public function test_scope_in_city_filters_correctly(): void
+    {
+        $city = City::factory()->create();
+        Unit::factory()->count(3)->inCity($city)->create();
+        Unit::factory()->count(2)->create(); // Different city
+
+        $units = Unit::inCity($city)->get();
+
+        $this->assertCount(3, $units);
+    }
+
+    public function test_scope_in_district_filters_correctly(): void
+    {
+        $district = District::factory()->create();
+        Unit::factory()->count(2)->inDistrict($district)->create();
+        Unit::factory()->count(4)->create(); // Different district
+
+        $units = Unit::inDistrict($district)->get();
+
+        $this->assertCount(2, $units);
+    }
+
+    public function test_scope_marketplace_filters_correctly(): void
+    {
+        Unit::factory()->count(3)->marketplace()->create();
+        Unit::factory()->count(2)->create(['is_marketplace' => false]);
+
+        $units = Unit::marketplace()->get();
+
+        $this->assertCount(3, $units);
+        $units->each(fn ($unit) => $this->assertTrue($unit->is_marketplace));
+    }
+
+    public function test_scope_not_marketplace_filters_correctly(): void
+    {
+        Unit::factory()->count(2)->marketplace()->create();
+        Unit::factory()->count(4)->create(['is_marketplace' => false]);
+
+        $units = Unit::notMarketplace()->get();
+
+        $this->assertCount(4, $units);
+        $units->each(fn ($unit) => $this->assertFalse($unit->is_marketplace));
+    }
+
+    public function test_scope_off_plan_sale_filters_correctly(): void
+    {
+        Unit::factory()->count(2)->offPlanSale()->create();
+        Unit::factory()->count(3)->create(['is_off_plan_sale' => false]);
+
+        $units = Unit::offPlanSale()->get();
+
+        $this->assertCount(2, $units);
+        $units->each(fn ($unit) => $this->assertTrue($unit->is_off_plan_sale));
+    }
+
+    public function test_scope_on_floor_filters_correctly(): void
+    {
+        Unit::factory()->count(3)->onFloor(5)->create();
+        Unit::factory()->count(2)->onFloor(10)->create();
+
+        $units = Unit::onFloor(5)->get();
+
+        $this->assertCount(3, $units);
+        $units->each(fn ($unit) => $this->assertEquals(5, $unit->floor_no));
+    }
+
+    public function test_scope_min_area_filters_correctly(): void
+    {
+        Unit::factory()->withArea(100)->create();
+        Unit::factory()->withArea(200)->create();
+        Unit::factory()->withArea(50)->create();
+
+        $units = Unit::minArea(100)->get();
+
+        $this->assertCount(2, $units);
+    }
+
+    public function test_scope_max_area_filters_correctly(): void
+    {
+        Unit::factory()->withArea(100)->create();
+        Unit::factory()->withArea(200)->create();
+        Unit::factory()->withArea(50)->create();
+
+        $units = Unit::maxArea(100)->get();
+
+        $this->assertCount(2, $units);
+    }
+
+    public function test_scope_area_between_filters_correctly(): void
+    {
+        Unit::factory()->withArea(50)->create();
+        Unit::factory()->withArea(100)->create();
+        Unit::factory()->withArea(150)->create();
+        Unit::factory()->withArea(200)->create();
+
+        $units = Unit::areaBetween(75, 175)->get();
+
+        $this->assertCount(2, $units);
+    }
+
+    public function test_scope_min_rent_filters_correctly(): void
+    {
+        Unit::factory()->withRent(5000)->create();
+        Unit::factory()->withRent(10000)->create();
+        Unit::factory()->withRent(2000)->create();
+
+        $units = Unit::minRent(5000)->get();
+
+        $this->assertCount(2, $units);
+    }
+
+    public function test_scope_max_rent_filters_correctly(): void
+    {
+        Unit::factory()->withRent(5000)->create();
+        Unit::factory()->withRent(10000)->create();
+        Unit::factory()->withRent(2000)->create();
+
+        $units = Unit::maxRent(5000)->get();
+
+        $this->assertCount(2, $units);
+    }
+
+    public function test_scope_rent_between_filters_correctly(): void
+    {
+        Unit::factory()->withRent(2000)->create();
+        Unit::factory()->withRent(5000)->create();
+        Unit::factory()->withRent(8000)->create();
+        Unit::factory()->withRent(12000)->create();
+
+        $units = Unit::rentBetween(4000, 9000)->get();
+
+        $this->assertCount(2, $units);
+    }
+
+    // ==========================================
+    // Helper Method Tests
+    // ==========================================
+
+    public function test_is_on_marketplace_returns_correct_value(): void
+    {
+        $marketplaceUnit = Unit::factory()->marketplace()->create();
+        $normalUnit = Unit::factory()->create(['is_marketplace' => false]);
+
+        $this->assertTrue($marketplaceUnit->isOnMarketplace());
+        $this->assertFalse($normalUnit->isOnMarketplace());
+    }
+
+    public function test_is_off_plan_sale_returns_correct_value(): void
+    {
+        $offPlanUnit = Unit::factory()->offPlanSale()->create();
+        $normalUnit = Unit::factory()->create(['is_off_plan_sale' => false]);
+
+        $this->assertTrue($offPlanUnit->isOffPlanSale());
+        $this->assertFalse($normalUnit->isOffPlanSale());
+    }
+
+    public function test_list_on_marketplace_updates_unit(): void
+    {
+        $unit = Unit::factory()->create(['is_marketplace' => false]);
+
+        $result = $unit->listOnMarketplace();
+
+        $this->assertTrue($result);
+        $this->assertTrue($unit->fresh()->is_marketplace);
+    }
+
+    public function test_remove_from_marketplace_updates_unit(): void
+    {
+        $unit = Unit::factory()->marketplace()->create();
+
+        $result = $unit->removeFromMarketplace();
+
+        $this->assertTrue($result);
+        $this->assertFalse($unit->fresh()->is_marketplace);
+    }
+
+    public function test_full_address_attribute_includes_all_parts(): void
+    {
+        $community = Community::factory()->create(['name' => 'Green Valley']);
+        $building = Building::factory()->forCommunity($community)->create(['name' => 'Tower A']);
+        $unit = Unit::factory()->forBuilding($building)->create(['name' => 'Unit 101']);
+
+        $this->assertEquals('Unit 101, Tower A, Green Valley', $unit->full_address);
+    }
+
+    public function test_full_address_attribute_without_building(): void
+    {
+        $community = Community::factory()->create(['name' => 'Green Valley']);
+        $unit = Unit::factory()->forCommunity($community)->withoutBuilding()->create(['name' => 'Villa 5']);
+
+        $this->assertEquals('Villa 5, Green Valley', $unit->full_address);
+    }
+
+    public function test_has_photos_returns_correct_value(): void
+    {
+        $unitWithPhotos = Unit::factory()->withPhotos(['photo1.jpg', 'photo2.jpg'])->create();
+        $unitWithoutPhotos = Unit::factory()->create(['photos' => null]);
+        $unitWithEmptyPhotos = Unit::factory()->create(['photos' => []]);
+
+        $this->assertTrue($unitWithPhotos->hasPhotos());
+        $this->assertFalse($unitWithoutPhotos->hasPhotos());
+        $this->assertFalse($unitWithEmptyPhotos->hasPhotos());
+    }
+
+    public function test_photo_count_attribute_returns_correct_count(): void
+    {
+        $unitWithPhotos = Unit::factory()->withPhotos(['photo1.jpg', 'photo2.jpg', 'photo3.jpg'])->create();
+        $unitWithoutPhotos = Unit::factory()->create(['photos' => null]);
+
+        $this->assertEquals(3, $unitWithPhotos->photo_count);
+        $this->assertEquals(0, $unitWithoutPhotos->photo_count);
+    }
+
+    public function test_has_map_coordinates_returns_correct_value(): void
+    {
+        $unitWithMap = Unit::factory()->withMap(25.2048, 55.2708)->create();
+        $unitWithoutMap = Unit::factory()->create(['map' => null]);
+        $unitWithIncompleteMap = Unit::factory()->create(['map' => ['latitude' => 25.2048]]);
+
+        $this->assertTrue($unitWithMap->hasMapCoordinates());
+        $this->assertFalse($unitWithoutMap->hasMapCoordinates());
+        $this->assertFalse($unitWithIncompleteMap->hasMapCoordinates());
+    }
+
+    // ==========================================
+    // Factory State Tests
+    // ==========================================
+
+    public function test_factory_studio_state(): void
+    {
+        $unit = Unit::factory()->studio()->create();
+
+        $this->assertStringContainsString('Studio', $unit->name);
+        $this->assertGreaterThanOrEqual(25, $unit->net_area);
+        $this->assertLessThanOrEqual(50, $unit->net_area);
+    }
+
+    public function test_factory_penthouse_state(): void
+    {
+        $unit = Unit::factory()->penthouse()->create();
+
+        $this->assertStringContainsString('Penthouse', $unit->name);
+        $this->assertGreaterThanOrEqual(200, $unit->net_area);
+        $this->assertGreaterThanOrEqual(30, $unit->floor_no);
+    }
+
+    public function test_factory_villa_state(): void
+    {
+        $unit = Unit::factory()->villa()->create();
+
+        $this->assertStringContainsString('Villa', $unit->name);
+        $this->assertGreaterThanOrEqual(300, $unit->net_area);
+        $this->assertEquals(1, $unit->floor_no);
+    }
+
+    public function test_factory_commercial_state(): void
+    {
+        $unit = Unit::factory()->commercial()->create();
+
+        $this->assertStringContainsString('Shop', $unit->name);
+        $this->assertLessThanOrEqual(3, $unit->floor_no);
+    }
+
+    public function test_factory_with_description_state(): void
+    {
+        $description = 'A beautiful apartment with sea view';
+        $unit = Unit::factory()->withDescription($description)->create();
+
+        $this->assertEquals($description, $unit->about);
+    }
+
+    // ==========================================
+    // Property Hierarchy Tests
+    // ==========================================
+
+    public function test_property_hierarchy_tenant_community_building_unit(): void
+    {
+        $tenant = Tenant::factory()->create();
+        $community = Community::factory()->forTenant($tenant)->create();
+        $building = Building::factory()->forCommunity($community)->create();
+        $unit = Unit::factory()->forBuilding($building)->create();
+
+        // Verify the hierarchy
+        $this->assertEquals($tenant->id, $unit->tenant_id);
+        $this->assertEquals($community->id, $unit->community_id);
+        $this->assertEquals($building->id, $unit->building_id);
+
+        // Verify through relationships
+        $this->assertTrue($unit->tenant->is($tenant));
+        $this->assertTrue($unit->community->is($community));
+        $this->assertTrue($unit->building->is($building));
+        $this->assertTrue($unit->building->community->is($community));
+        $this->assertTrue($unit->community->tenant->is($tenant));
+    }
+
+    public function test_building_has_many_units(): void
+    {
+        $building = Building::factory()->create();
+        Unit::factory()->count(5)->forBuilding($building)->create();
+
+        $this->assertCount(5, $building->units);
+        $building->units->each(fn ($unit) => $this->assertEquals($building->id, $unit->building_id));
+    }
+
+    // ==========================================
+    // Multi-Tenant Isolation Tests
+    // ==========================================
+
+    public function test_units_are_isolated_by_tenant(): void
+    {
+        $tenant1 = Tenant::factory()->create();
+        $tenant2 = Tenant::factory()->create();
+
+        Unit::factory()->count(4)->forTenant($tenant1)->create();
+        Unit::factory()->count(3)->forTenant($tenant2)->create();
+
+        $tenant1Units = Unit::forTenant($tenant1)->get();
+        $tenant2Units = Unit::forTenant($tenant2)->get();
+
+        $this->assertCount(4, $tenant1Units);
+        $this->assertCount(3, $tenant2Units);
+
+        // Ensure no cross-tenant data
+        $tenant1Units->each(fn ($unit) => $this->assertEquals($tenant1->id, $unit->tenant_id));
+        $tenant2Units->each(fn ($unit) => $this->assertEquals($tenant2->id, $unit->tenant_id));
+    }
+
+    // ==========================================
+    // Cascade Delete Tests
+    // ==========================================
+
+    public function test_units_are_deleted_when_community_is_deleted(): void
+    {
+        $community = Community::factory()->create();
+        $unit = Unit::factory()->forCommunity($community)->withoutBuilding()->create();
+
+        $community->forceDelete();
+
+        $this->assertDatabaseMissing('units', ['id' => $unit->id]);
+    }
+
+    public function test_units_are_deleted_when_tenant_is_deleted(): void
+    {
+        $tenant = Tenant::factory()->create();
+        $unit = Unit::factory()->forTenant($tenant)->create();
+
+        $tenant->forceDelete();
+
+        $this->assertDatabaseMissing('units', ['id' => $unit->id]);
+    }
+
+    public function test_unit_building_id_is_nulled_when_building_is_deleted(): void
+    {
+        $building = Building::factory()->create();
+        $unit = Unit::factory()->forBuilding($building)->create();
+
+        $building->forceDelete();
+
+        $this->assertDatabaseHas('units', [
+            'id' => $unit->id,
+            'building_id' => null,
+        ]);
+    }
+
+    // ==========================================
+    // Chained Scope Tests
+    // ==========================================
+
+    public function test_multiple_scopes_can_be_chained(): void
+    {
+        $tenant = Tenant::factory()->create();
+        $community = Community::factory()->forTenant($tenant)->create();
+        $building = Building::factory()->forCommunity($community)->create();
+
+        // Create various units
+        Unit::factory()->forBuilding($building)->marketplace()->onFloor(5)->withArea(150)->create();
+        Unit::factory()->forBuilding($building)->marketplace()->onFloor(5)->withArea(200)->create();
+        Unit::factory()->forBuilding($building)->onFloor(5)->withArea(150)->create(); // Not marketplace
+        Unit::factory()->forBuilding($building)->marketplace()->onFloor(10)->withArea(150)->create(); // Different floor
+
+        $units = Unit::forTenant($tenant)
+            ->forCommunity($community)
+            ->forBuilding($building)
+            ->marketplace()
+            ->onFloor(5)
+            ->minArea(100)
+            ->get();
+
+        $this->assertCount(2, $units);
+    }
+}


### PR DESCRIPTION
## Summary

Implements Issue #12: Units Entity - the third level in the property hierarchy (Community → Building → Unit).

### Changes
- **Migration**: Full units table schema with all required fields, foreign keys, and indexes
- **Model**: Complete Unit model with relationships, scopes, and helper methods
- **Factory**: UnitFactory with 20 states for flexible test data
- **Tests**: 55 tests with 151 assertions

### Key Features
- Units can belong to a building or exist standalone in a community
- Category and type classification system
- Status tracking via Status model (domain: unit)
- Marketplace and off-plan sale flags
- Area and rent range filtering scopes
- Full property hierarchy support

### Schema
```php
- tenant_id (required)
- community_id (required)
- building_id (nullable)
- unit_category_id (required)
- unit_type_id (required)
- status_id (nullable)
- city_id, district_id (nullable)
- name, floor_no, net_area, year_built, market_rent, about
- map (JSON), photos (JSON)
- is_marketplace, is_off_plan_sale (boolean)
```

### Test Results
All 55 tests pass with 151 assertions covering model attributes, relationships, scopes, helpers, factory states, property hierarchy, multi-tenant isolation, and cascade deletes.

## Test plan
- [x] Unit tests pass: `php artisan test tests/Feature/UnitEntityTest.php`
- [x] Code formatted with Pint

Closes #12

🤖 Generated with [Claude Code](https://claude.com/claude-code)