### PR TITLE
Issue #37: Marketplace Visits Entity

### DIFF
--- a/app/Models/MarketplaceVisit.php
+++ b/app/Models/MarketplaceVisit.php
@@ -1,0 +1,284 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Attributes\Fillable;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Database\Eloquent\SoftDeletes;
+
+/**
+ * Represents a scheduled property visit in the marketplace.
+ */
+#[Fillable([
+    'tenant_id',
+    'marketplace_unit_id',
+    'marketplace_customer_id',
+    'status_id',
+    'visit_date',
+    'visit_time',
+    'visit_end_time',
+    'duration_minutes',
+    'is_all_day',
+    'assigned_agent',
+    'customer_notes',
+    'agent_notes',
+    'feedback',
+    'interest_level',
+    'outcome',
+    'confirmed_at',
+    'confirmed_by',
+    'completed_at',
+    'canceled_at',
+    'cancellation_reason',
+    'rescheduled_from',
+    'rescheduled_at',
+])]
+class MarketplaceVisit extends Model
+{
+    use HasFactory, SoftDeletes;
+
+    /**
+     * Get the attributes that should be cast.
+     */
+    protected function casts(): array
+    {
+        return [
+            'visit_date' => 'date',
+            'is_all_day' => 'boolean',
+            'confirmed_at' => 'datetime',
+            'completed_at' => 'datetime',
+            'canceled_at' => 'datetime',
+            'rescheduled_at' => 'datetime',
+        ];
+    }
+
+    /**
+     * Get the tenant that owns this visit.
+     */
+    public function tenant(): BelongsTo
+    {
+        return $this->belongsTo(Tenant::class);
+    }
+
+    /**
+     * Get the marketplace unit being visited.
+     */
+    public function marketplaceUnit(): BelongsTo
+    {
+        return $this->belongsTo(MarketplaceUnit::class);
+    }
+
+    /**
+     * Get the customer making the visit.
+     */
+    public function customer(): BelongsTo
+    {
+        return $this->belongsTo(MarketplaceCustomer::class, 'marketplace_customer_id');
+    }
+
+    /**
+     * Get the status of this visit.
+     */
+    public function status(): BelongsTo
+    {
+        return $this->belongsTo(Status::class);
+    }
+
+    /**
+     * Get the assigned agent.
+     */
+    public function agent(): BelongsTo
+    {
+        return $this->belongsTo(Contact::class, 'assigned_agent');
+    }
+
+    /**
+     * Get the contact who confirmed the visit.
+     */
+    public function confirmedByContact(): BelongsTo
+    {
+        return $this->belongsTo(Contact::class, 'confirmed_by');
+    }
+
+    /**
+     * Get the visit this was rescheduled from.
+     */
+    public function rescheduledFromVisit(): BelongsTo
+    {
+        return $this->belongsTo(MarketplaceVisit::class, 'rescheduled_from');
+    }
+
+    /**
+     * Confirm the visit.
+     */
+    public function confirm(?int $confirmedBy = null): void
+    {
+        $status = Status::where('domain', 'marketplace_visit')
+            ->where('slug', 'marketplace_visit_confirmed')
+            ->first();
+
+        $this->update([
+            'status_id' => $status?->id ?? $this->status_id,
+            'confirmed_at' => now(),
+            'confirmed_by' => $confirmedBy,
+        ]);
+    }
+
+    /**
+     * Complete the visit.
+     */
+    public function complete(?string $outcome = null, ?int $interestLevel = null): void
+    {
+        $status = Status::where('domain', 'marketplace_visit')
+            ->where('slug', 'marketplace_visit_completed')
+            ->first();
+
+        $this->update([
+            'status_id' => $status?->id ?? $this->status_id,
+            'completed_at' => now(),
+            'outcome' => $outcome,
+            'interest_level' => $interestLevel,
+        ]);
+    }
+
+    /**
+     * Cancel the visit.
+     */
+    public function cancel(?string $reason = null): void
+    {
+        $status = Status::where('domain', 'marketplace_visit')
+            ->where('slug', 'marketplace_visit_canceled')
+            ->first();
+
+        $this->update([
+            'status_id' => $status?->id ?? $this->status_id,
+            'canceled_at' => now(),
+            'cancellation_reason' => $reason,
+        ]);
+    }
+
+    /**
+     * Mark as no show.
+     */
+    public function markAsNoShow(): void
+    {
+        $status = Status::where('domain', 'marketplace_visit')
+            ->where('slug', 'marketplace_visit_no_show')
+            ->first();
+
+        $this->update([
+            'status_id' => $status?->id ?? $this->status_id,
+        ]);
+    }
+
+    /**
+     * Reschedule the visit.
+     */
+    public function reschedule(string $newDate, ?string $newTime = null): self
+    {
+        // Cancel the current visit
+        $this->cancel('Rescheduled');
+
+        // Create a new visit with the same details
+        return static::create([
+            'tenant_id' => $this->tenant_id,
+            'marketplace_unit_id' => $this->marketplace_unit_id,
+            'marketplace_customer_id' => $this->marketplace_customer_id,
+            'status_id' => $this->status_id,
+            'visit_date' => $newDate,
+            'visit_time' => $newTime ?? $this->visit_time,
+            'visit_end_time' => $this->visit_end_time,
+            'duration_minutes' => $this->duration_minutes,
+            'is_all_day' => $this->is_all_day,
+            'assigned_agent' => $this->assigned_agent,
+            'customer_notes' => $this->customer_notes,
+            'rescheduled_from' => $this->id,
+            'rescheduled_at' => now(),
+        ]);
+    }
+
+    /**
+     * Assign an agent to this visit.
+     */
+    public function assignAgent(int $agentId): void
+    {
+        $this->update(['assigned_agent' => $agentId]);
+    }
+
+    /**
+     * Add feedback to the visit.
+     */
+    public function addFeedback(string $feedback, ?int $interestLevel = null): void
+    {
+        $this->update([
+            'feedback' => $feedback,
+            'interest_level' => $interestLevel,
+        ]);
+    }
+
+    /**
+     * Check if the visit is pending.
+     */
+    public function isPending(): bool
+    {
+        return $this->status?->slug === 'marketplace_visit_pending';
+    }
+
+    /**
+     * Check if the visit is confirmed.
+     */
+    public function isConfirmed(): bool
+    {
+        return $this->status?->slug === 'marketplace_visit_confirmed' || $this->confirmed_at !== null;
+    }
+
+    /**
+     * Check if the visit is completed.
+     */
+    public function isCompleted(): bool
+    {
+        return $this->status?->slug === 'marketplace_visit_completed' || $this->completed_at !== null;
+    }
+
+    /**
+     * Check if the visit is canceled.
+     */
+    public function isCanceled(): bool
+    {
+        return $this->status?->slug === 'marketplace_visit_canceled' || $this->canceled_at !== null;
+    }
+
+    /**
+     * Check if the visit is a no show.
+     */
+    public function isNoShow(): bool
+    {
+        return $this->status?->slug === 'marketplace_visit_no_show';
+    }
+
+    /**
+     * Check if the visit is rescheduled.
+     */
+    public function isRescheduled(): bool
+    {
+        return $this->rescheduled_from !== null;
+    }
+
+    /**
+     * Check if the visit is upcoming (scheduled for the future).
+     */
+    public function isUpcoming(): bool
+    {
+        return $this->visit_date->isFuture() && ! $this->isCanceled() && ! $this->isCompleted();
+    }
+
+    /**
+     * Check if the visit is today.
+     */
+    public function isToday(): bool
+    {
+        return $this->visit_date->isToday();
+    }
+}

--- a/database/factories/MarketplaceUnitFactory.php
+++ b/database/factories/MarketplaceUnitFactory.php
@@ -36,11 +36,10 @@ class MarketplaceUnitFactory extends Factory
         return [
             'tenant_id' => Tenant::factory(),
             'unit_id' => Unit::factory(),
-            'status_id' => fn () => Status::factory()->create([
-                'domain' => 'marketplace',
-                'slug' => 'marketplace_available',
-                'name' => 'Available',
-            ])->id,
+            'status_id' => fn () => Status::firstOrCreate(
+                ['slug' => 'marketplace_available'],
+                ['domain' => 'marketplace', 'name' => 'Available']
+            )->id,
             'listing_title_en' => $listing['en'],
             'listing_title_ar' => $listing['ar'],
             'listing_description_en' => fake()->paragraph(3),

--- a/database/factories/MarketplaceVisitFactory.php
+++ b/database/factories/MarketplaceVisitFactory.php
@@ -1,0 +1,166 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Models\Contact;
+use App\Models\MarketplaceCustomer;
+use App\Models\MarketplaceUnit;
+use App\Models\MarketplaceVisit;
+use App\Models\Status;
+use App\Models\Tenant;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+/**
+ * @extends Factory<MarketplaceVisit>
+ */
+class MarketplaceVisitFactory extends Factory
+{
+    /**
+     * Define the model's default state.
+     *
+     * @return array<string, mixed>
+     */
+    public function definition(): array
+    {
+        $visitDate = fake()->dateTimeBetween('now', '+30 days');
+        $startHour = fake()->numberBetween(9, 17);
+        $duration = fake()->randomElement([30, 45, 60, 90, 120]);
+
+        return [
+            'tenant_id' => Tenant::factory(),
+            'marketplace_unit_id' => MarketplaceUnit::factory(),
+            'marketplace_customer_id' => MarketplaceCustomer::factory(),
+            'status_id' => fn () => Status::firstOrCreate(
+                ['slug' => 'marketplace_visit_pending'],
+                ['domain' => 'marketplace_visit', 'name' => 'Pending']
+            )->id,
+            'visit_date' => $visitDate,
+            'visit_time' => sprintf('%02d:00:00', $startHour),
+            'visit_end_time' => sprintf('%02d:%02d:00', $startHour + intdiv($duration, 60), $duration % 60),
+            'duration_minutes' => $duration,
+            'is_all_day' => false,
+            'assigned_agent' => fake()->optional(0.7)->passthrough(Contact::factory()),
+            'customer_notes' => fake()->optional(0.5)->sentence(),
+        ];
+    }
+
+    /**
+     * Indicate that the visit is pending.
+     */
+    public function pending(): static
+    {
+        return $this->state(fn (array $attributes) => [
+            'status_id' => fn () => Status::firstOrCreate(
+                ['slug' => 'marketplace_visit_pending'],
+                ['domain' => 'marketplace_visit', 'name' => 'Pending']
+            )->id,
+            'visit_date' => fake()->dateTimeBetween('+1 day', '+30 days'),
+        ]);
+    }
+
+    /**
+     * Indicate that the visit is confirmed.
+     */
+    public function confirmed(): static
+    {
+        return $this->state(fn (array $attributes) => [
+            'status_id' => fn () => Status::firstOrCreate(
+                ['slug' => 'marketplace_visit_confirmed'],
+                ['domain' => 'marketplace_visit', 'name' => 'Confirmed']
+            )->id,
+            'confirmed_at' => now()->subHours(fake()->numberBetween(1, 48)),
+            'confirmed_by' => Contact::factory(),
+            'visit_date' => fake()->dateTimeBetween('+1 day', '+14 days'),
+        ]);
+    }
+
+    /**
+     * Indicate that the visit is completed.
+     */
+    public function completed(): static
+    {
+        return $this->state(fn (array $attributes) => [
+            'status_id' => fn () => Status::firstOrCreate(
+                ['slug' => 'marketplace_visit_completed'],
+                ['domain' => 'marketplace_visit', 'name' => 'Completed']
+            )->id,
+            'visit_date' => fake()->dateTimeBetween('-30 days', '-1 day'),
+            'confirmed_at' => now()->subDays(fake()->numberBetween(2, 30)),
+            'confirmed_by' => Contact::factory(),
+            'completed_at' => now()->subDays(fake()->numberBetween(1, 7)),
+            'outcome' => fake()->randomElement(['interested', 'not_interested', 'follow_up', 'offer_made']),
+            'interest_level' => fake()->numberBetween(1, 10),
+            'feedback' => fake()->optional(0.7)->paragraph(),
+            'agent_notes' => fake()->optional(0.5)->sentence(),
+        ]);
+    }
+
+    /**
+     * Indicate that the visit is canceled.
+     */
+    public function canceled(): static
+    {
+        return $this->state(fn (array $attributes) => [
+            'status_id' => fn () => Status::firstOrCreate(
+                ['slug' => 'marketplace_visit_canceled'],
+                ['domain' => 'marketplace_visit', 'name' => 'Canceled']
+            )->id,
+            'canceled_at' => now()->subHours(fake()->numberBetween(1, 72)),
+            'cancellation_reason' => fake()->randomElement([
+                'Customer request',
+                'Schedule conflict',
+                'Unit no longer available',
+                'Agent unavailable',
+                'Rescheduled',
+            ]),
+        ]);
+    }
+
+    /**
+     * Indicate that the visit was a no-show.
+     */
+    public function noShow(): static
+    {
+        return $this->state(fn (array $attributes) => [
+            'status_id' => fn () => Status::firstOrCreate(
+                ['slug' => 'marketplace_visit_no_show'],
+                ['domain' => 'marketplace_visit', 'name' => 'No Show']
+            )->id,
+            'visit_date' => fake()->dateTimeBetween('-14 days', '-1 day'),
+            'confirmed_at' => now()->subDays(fake()->numberBetween(2, 14)),
+        ]);
+    }
+
+    /**
+     * Indicate that the visit is an all-day event.
+     */
+    public function allDay(): static
+    {
+        return $this->state(fn (array $attributes) => [
+            'is_all_day' => true,
+            'visit_time' => null,
+            'visit_end_time' => null,
+            'duration_minutes' => 480, // 8 hours
+        ]);
+    }
+
+    /**
+     * Indicate that the visit is today.
+     */
+    public function today(): static
+    {
+        return $this->state(fn (array $attributes) => [
+            'visit_date' => today(),
+        ]);
+    }
+
+    /**
+     * Indicate that the visit has an assigned agent.
+     */
+    public function withAgent(): static
+    {
+        return $this->state(fn (array $attributes) => [
+            'assigned_agent' => Contact::factory(),
+        ]);
+    }
+}

--- a/database/migrations/2026_04_13_105735_create_marketplace_visits_table.php
+++ b/database/migrations/2026_04_13_105735_create_marketplace_visits_table.php
@@ -1,0 +1,69 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('marketplace_visits', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('tenant_id')->constrained('tenants')->cascadeOnDelete();
+            $table->foreignId('marketplace_unit_id')->constrained('marketplace_units')->cascadeOnDelete();
+            $table->foreignId('marketplace_customer_id')->constrained('marketplace_customers')->cascadeOnDelete();
+            $table->foreignId('status_id')->constrained('statuses')->restrictOnDelete();
+
+            // Scheduling
+            $table->date('visit_date');
+            $table->time('visit_time')->nullable();
+            $table->time('visit_end_time')->nullable();
+            $table->integer('duration_minutes')->default(60);
+            $table->boolean('is_all_day')->default(false);
+
+            // Assignment
+            $table->foreignId('assigned_agent')->nullable()->constrained('contacts')->nullOnDelete();
+
+            // Visit details
+            $table->text('customer_notes')->nullable();
+            $table->text('agent_notes')->nullable();
+            $table->text('feedback')->nullable();
+            $table->integer('interest_level')->nullable();
+
+            // Visit outcome
+            $table->enum('outcome', ['interested', 'not_interested', 'follow_up', 'offer_made', 'pending'])->nullable();
+
+            // Confirmation and completion tracking
+            $table->timestamp('confirmed_at')->nullable();
+            $table->foreignId('confirmed_by')->nullable()->constrained('contacts')->nullOnDelete();
+            $table->timestamp('completed_at')->nullable();
+            $table->timestamp('canceled_at')->nullable();
+            $table->text('cancellation_reason')->nullable();
+
+            // Rescheduling
+            $table->foreignId('rescheduled_from')->nullable()->constrained('marketplace_visits')->nullOnDelete();
+            $table->timestamp('rescheduled_at')->nullable();
+
+            $table->timestamps();
+            $table->softDeletes();
+
+            // Indexes
+            $table->index(['marketplace_unit_id', 'visit_date']);
+            $table->index(['marketplace_customer_id', 'visit_date']);
+            $table->index('status_id');
+            $table->index('assigned_agent');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('marketplace_visits');
+    }
+};

--- a/tests/Feature/MarketplaceVisitTest.php
+++ b/tests/Feature/MarketplaceVisitTest.php
@@ -1,0 +1,290 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\Contact;
+use App\Models\MarketplaceCustomer;
+use App\Models\MarketplaceUnit;
+use App\Models\MarketplaceVisit;
+use App\Models\Status;
+use App\Models\Tenant;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class MarketplaceVisitTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_can_create_marketplace_visit(): void
+    {
+        $visit = MarketplaceVisit::factory()->create();
+
+        $this->assertDatabaseHas('marketplace_visits', [
+            'id' => $visit->id,
+        ]);
+    }
+
+    public function test_belongs_to_tenant(): void
+    {
+        $tenant = Tenant::factory()->create();
+        $visit = MarketplaceVisit::factory()->create(['tenant_id' => $tenant->id]);
+
+        $this->assertInstanceOf(Tenant::class, $visit->tenant);
+        $this->assertEquals($tenant->id, $visit->tenant->id);
+    }
+
+    public function test_belongs_to_marketplace_unit(): void
+    {
+        $unit = MarketplaceUnit::factory()->create();
+        $visit = MarketplaceVisit::factory()->create(['marketplace_unit_id' => $unit->id]);
+
+        $this->assertInstanceOf(MarketplaceUnit::class, $visit->marketplaceUnit);
+        $this->assertEquals($unit->id, $visit->marketplaceUnit->id);
+    }
+
+    public function test_belongs_to_customer(): void
+    {
+        $customer = MarketplaceCustomer::factory()->create();
+        $visit = MarketplaceVisit::factory()->create(['marketplace_customer_id' => $customer->id]);
+
+        $this->assertInstanceOf(MarketplaceCustomer::class, $visit->customer);
+        $this->assertEquals($customer->id, $visit->customer->id);
+    }
+
+    public function test_belongs_to_status(): void
+    {
+        $status = Status::factory()->create([
+            'domain' => 'marketplace_visit',
+            'slug' => 'marketplace_visit_pending',
+        ]);
+        $visit = MarketplaceVisit::factory()->create(['status_id' => $status->id]);
+
+        $this->assertInstanceOf(Status::class, $visit->status);
+        $this->assertEquals($status->id, $visit->status->id);
+    }
+
+    public function test_belongs_to_agent(): void
+    {
+        $agent = Contact::factory()->create();
+        $visit = MarketplaceVisit::factory()->withAgent()->create(['assigned_agent' => $agent->id]);
+
+        $this->assertInstanceOf(Contact::class, $visit->agent);
+        $this->assertEquals($agent->id, $visit->agent->id);
+    }
+
+    public function test_belongs_to_confirmed_by_contact(): void
+    {
+        $contact = Contact::factory()->create();
+        $visit = MarketplaceVisit::factory()->confirmed()->create(['confirmed_by' => $contact->id]);
+
+        $this->assertInstanceOf(Contact::class, $visit->confirmedByContact);
+        $this->assertEquals($contact->id, $visit->confirmedByContact->id);
+    }
+
+    public function test_belongs_to_rescheduled_from_visit(): void
+    {
+        $originalVisit = MarketplaceVisit::factory()->canceled()->create();
+        $newVisit = MarketplaceVisit::factory()->create(['rescheduled_from' => $originalVisit->id]);
+
+        $this->assertInstanceOf(MarketplaceVisit::class, $newVisit->rescheduledFromVisit);
+        $this->assertEquals($originalVisit->id, $newVisit->rescheduledFromVisit->id);
+    }
+
+    public function test_can_confirm_visit(): void
+    {
+        Status::factory()->create([
+            'domain' => 'marketplace_visit',
+            'slug' => 'marketplace_visit_confirmed',
+            'name' => 'Confirmed',
+        ]);
+        $contact = Contact::factory()->create();
+        $visit = MarketplaceVisit::factory()->pending()->create();
+
+        $visit->confirm($contact->id);
+
+        $fresh = $visit->fresh();
+        $this->assertNotNull($fresh->confirmed_at);
+        $this->assertEquals($contact->id, $fresh->confirmed_by);
+    }
+
+    public function test_can_complete_visit(): void
+    {
+        Status::factory()->create([
+            'domain' => 'marketplace_visit',
+            'slug' => 'marketplace_visit_completed',
+            'name' => 'Completed',
+        ]);
+        $visit = MarketplaceVisit::factory()->confirmed()->create();
+
+        $visit->complete('interested', 8);
+
+        $fresh = $visit->fresh();
+        $this->assertNotNull($fresh->completed_at);
+        $this->assertEquals('interested', $fresh->outcome);
+        $this->assertEquals(8, $fresh->interest_level);
+    }
+
+    public function test_can_cancel_visit(): void
+    {
+        Status::factory()->create([
+            'domain' => 'marketplace_visit',
+            'slug' => 'marketplace_visit_canceled',
+            'name' => 'Canceled',
+        ]);
+        $visit = MarketplaceVisit::factory()->pending()->create();
+
+        $visit->cancel('Customer request');
+
+        $fresh = $visit->fresh();
+        $this->assertNotNull($fresh->canceled_at);
+        $this->assertEquals('Customer request', $fresh->cancellation_reason);
+    }
+
+    public function test_can_mark_as_no_show(): void
+    {
+        Status::factory()->create([
+            'domain' => 'marketplace_visit',
+            'slug' => 'marketplace_visit_no_show',
+            'name' => 'No Show',
+        ]);
+        $visit = MarketplaceVisit::factory()->confirmed()->create();
+
+        $visit->markAsNoShow();
+
+        $this->assertTrue($visit->fresh()->isNoShow());
+    }
+
+    public function test_can_reschedule_visit(): void
+    {
+        Status::factory()->create([
+            'domain' => 'marketplace_visit',
+            'slug' => 'marketplace_visit_canceled',
+            'name' => 'Canceled',
+        ]);
+        $visit = MarketplaceVisit::factory()->pending()->create();
+        $newDate = now()->addDays(7)->format('Y-m-d');
+
+        $newVisit = $visit->reschedule($newDate, '14:00:00');
+
+        // Original visit should be canceled
+        $this->assertNotNull($visit->fresh()->canceled_at);
+        $this->assertEquals('Rescheduled', $visit->fresh()->cancellation_reason);
+
+        // New visit should be created
+        $this->assertEquals($newDate, $newVisit->visit_date->format('Y-m-d'));
+        $this->assertEquals('14:00:00', $newVisit->visit_time);
+        $this->assertEquals($visit->id, $newVisit->rescheduled_from);
+        $this->assertNotNull($newVisit->rescheduled_at);
+    }
+
+    public function test_can_assign_agent(): void
+    {
+        $agent = Contact::factory()->create();
+        $visit = MarketplaceVisit::factory()->create(['assigned_agent' => null]);
+
+        $visit->assignAgent($agent->id);
+
+        $this->assertEquals($agent->id, $visit->fresh()->assigned_agent);
+    }
+
+    public function test_can_add_feedback(): void
+    {
+        $visit = MarketplaceVisit::factory()->confirmed()->create();
+
+        $visit->addFeedback('Great property, interested in making an offer', 9);
+
+        $fresh = $visit->fresh();
+        $this->assertEquals('Great property, interested in making an offer', $fresh->feedback);
+        $this->assertEquals(9, $fresh->interest_level);
+    }
+
+    public function test_is_pending_returns_true_for_pending(): void
+    {
+        $status = Status::factory()->create([
+            'domain' => 'marketplace_visit',
+            'slug' => 'marketplace_visit_pending',
+        ]);
+        $visit = MarketplaceVisit::factory()->create(['status_id' => $status->id]);
+
+        $this->assertTrue($visit->isPending());
+    }
+
+    public function test_is_confirmed_returns_true_for_confirmed(): void
+    {
+        $visit = MarketplaceVisit::factory()->confirmed()->create();
+
+        $this->assertTrue($visit->isConfirmed());
+    }
+
+    public function test_is_completed_returns_true_for_completed(): void
+    {
+        $visit = MarketplaceVisit::factory()->completed()->create();
+
+        $this->assertTrue($visit->isCompleted());
+    }
+
+    public function test_is_canceled_returns_true_for_canceled(): void
+    {
+        $visit = MarketplaceVisit::factory()->canceled()->create();
+
+        $this->assertTrue($visit->isCanceled());
+    }
+
+    public function test_is_no_show_returns_true_for_no_show(): void
+    {
+        $visit = MarketplaceVisit::factory()->noShow()->create();
+
+        $this->assertTrue($visit->isNoShow());
+    }
+
+    public function test_is_rescheduled_returns_true_for_rescheduled(): void
+    {
+        $originalVisit = MarketplaceVisit::factory()->create();
+        $visit = MarketplaceVisit::factory()->create(['rescheduled_from' => $originalVisit->id]);
+
+        $this->assertTrue($visit->isRescheduled());
+    }
+
+    public function test_is_upcoming_returns_true_for_future_visit(): void
+    {
+        $visit = MarketplaceVisit::factory()->pending()->create([
+            'visit_date' => now()->addDays(5),
+        ]);
+
+        $this->assertTrue($visit->isUpcoming());
+    }
+
+    public function test_is_upcoming_returns_false_for_completed_visit(): void
+    {
+        $visit = MarketplaceVisit::factory()->completed()->create([
+            'visit_date' => now()->addDays(5),
+        ]);
+
+        $this->assertFalse($visit->isUpcoming());
+    }
+
+    public function test_is_today_returns_true_for_today_visit(): void
+    {
+        $visit = MarketplaceVisit::factory()->today()->create();
+
+        $this->assertTrue($visit->isToday());
+    }
+
+    public function test_all_day_visit(): void
+    {
+        $visit = MarketplaceVisit::factory()->allDay()->create();
+
+        $this->assertTrue($visit->is_all_day);
+        $this->assertNull($visit->visit_time);
+        $this->assertNull($visit->visit_end_time);
+    }
+
+    public function test_soft_deletes_marketplace_visit(): void
+    {
+        $visit = MarketplaceVisit::factory()->create();
+
+        $visit->delete();
+
+        $this->assertSoftDeleted('marketplace_visits', ['id' => $visit->id]);
+    }
+}


### PR DESCRIPTION
## Summary
- Implements marketplace visit scheduling and management system
- Creates comprehensive workflow for property visits (pending → confirmed → completed/canceled/no-show)
- Supports reschedule functionality creating new visits linked to original
- Adds agent assignment, customer notes, and feedback tracking
- Includes outcome tracking (interested, not_interested, follow_up, offer_made)

## Changes
- `database/migrations/2026_04_13_105735_create_marketplace_visits_table.php` - Migration with full scheduling schema
- `app/Models/MarketplaceVisit.php` - Model with 12+ business methods and 8 status checks
- `database/factories/MarketplaceVisitFactory.php` - Factory with 8 states
- `database/factories/MarketplaceUnitFactory.php` - Fixed status unique constraint
- `tests/Feature/MarketplaceVisitTest.php` - 26 tests, 45 assertions

## Test plan
- [x] All 26 tests pass
- [x] Visit workflow transitions work correctly
- [x] Reschedule creates new visit and cancels original
- [x] Factory states generate valid data
- [x] Pint formatting passes

Closes #37

🤖 Generated with [Claude Code](https://claude.com/claude-code)