### PR TITLE
feat: RbacSeeder — 186 permissions, 12 roles, bilingual names, presets

### DIFF
--- a/.claude/agent-memory/qa/MEMORY.md
+++ b/.claude/agent-memory/qa/MEMORY.md
@@ -35,3 +35,9 @@ Append concise notes as you learn. Keep this under 200 lines via curation.
 
 ## Past work index
 _(append one line per QA report: `PR #N — <AC count / tests added> — <any persistent issue>`)_
+- PR #118 — 5 ACs / 5 gap tests added — PermissionSubject has 31 cases (issue says 30); PermissionAction has EXPORT/IMPORT (issue says RESTORE/FORCE_DELETE): both flagged for PM/Tech Lead sign-off.
+- PR #119 — 5 ACs / 4 gap tests added — 186 vs 180 permission count discrepancy persists (31 subjects, issue says 30); flagged again for PM sign-off. All 28 tests pass.
+
+## Migration rollback tests
+- Use `Artisan::call('migrate:rollback', ['--step' => N, '--force' => true])` then re-apply with `Artisan::call('migrate', ['--force' => true])` to restore DB for subsequent tests. Use Schema::hasColumn() to assert before/after.
+- Only works reliably when migrations are the last N in the batch — verify step count against actual migration files.

--- a/database/migrations/2026_04_23_101408_add_bilingual_and_tenant_columns_to_permissions_table.php
+++ b/database/migrations/2026_04_23_101408_add_bilingual_and_tenant_columns_to_permissions_table.php
@@ -1,0 +1,36 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+/**
+ * Adds bilingual label columns and a tenant-scope column to the permissions table.
+ *
+ * - name_en / name_ar : human-readable labels for display in the UI
+ * - account_tenant_id : NULL = system-wide; non-null = tenant-custom permission
+ *
+ * System-wide permissions (account_tenant_id IS NULL) are seeded by RbacSeeder.
+ * Tenant-custom permissions (account_tenant_id IS NOT NULL) are created by admins
+ * within a tenant context and must never be deleted by the RBAC seeder.
+ */
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('permissions', function (Blueprint $table) {
+            $table->string('name_en')->nullable()->after('action');
+            $table->string('name_ar')->nullable()->after('name_en');
+            $table->unsignedBigInteger('account_tenant_id')->nullable()->after('name_ar');
+            $table->index('account_tenant_id', 'permissions_account_tenant_id_index');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('permissions', function (Blueprint $table) {
+            $table->dropIndex('permissions_account_tenant_id_index');
+            $table->dropColumn(['name_en', 'name_ar', 'account_tenant_id']);
+        });
+    }
+};

--- a/database/seeders/DatabaseSeeder.php
+++ b/database/seeders/DatabaseSeeder.php
@@ -11,6 +11,7 @@ class DatabaseSeeder extends Seeder
      */
     public function run(): void
     {
+        $this->call(RbacSeeder::class);
         $this->call(DemoAccountSeeder::class);
     }
 }

--- a/database/seeders/DemoAccountSeeder.php
+++ b/database/seeders/DemoAccountSeeder.php
@@ -74,7 +74,7 @@ class DemoAccountSeeder extends Seeder
             FeatureSeeder::class,
             AmenitySeeder::class,
             CommonListSeeder::class,
-            RolesSeeder::class,
+            RbacSeeder::class,
             SubscriptionPlanSeeder::class,
         ]);
     }

--- a/database/seeders/RbacSeeder.php
+++ b/database/seeders/RbacSeeder.php
@@ -1,0 +1,438 @@
+<?php
+
+namespace Database\Seeders;
+
+use App\Enums\PermissionAction;
+use App\Enums\PermissionSubject;
+use App\Enums\RoleType;
+use App\Models\Permission;
+use App\Models\Role;
+use Illuminate\Database\Seeder;
+use Illuminate\Support\Facades\DB;
+use Spatie\Permission\PermissionRegistrar;
+
+/**
+ * RbacSeeder — seeds the 186 system-wide permissions and 12 default roles.
+ *
+ * ## Permission matrix
+ * 31 PermissionSubject cases × 6 PermissionAction cases = 186 permissions.
+ * All system-wide permissions have account_tenant_id = NULL.
+ *
+ * ## Role presets (permission assignment rationale)
+ *
+ * UserRole defaults:
+ *   - accountAdmins : ALL 186 permissions — full platform control for the account owner.
+ *   - admins        : All subjects except companyProfile, invoiceSettings, leaseSettings
+ *                     (billing/legal config kept for account owner only).
+ *   - managers      : Operational subjects only; excludes admin/settings subjects.
+ *   - owners        : Property-owner self-service: VIEW+CREATE+UPDATE on their own resources.
+ *   - tenants       : Resident self-service: VIEW+CREATE on day-to-day subjects.
+ *   - dependents    : Read-only access to shared amenities and announcements.
+ *   - professionals : VIEW+UPDATE on service-related subjects (handling work orders).
+ *
+ * AdminRole defaults (back-office staff accounts):
+ *   - Admins                  : ALL 186 permissions (mirror of accountAdmins for back-office).
+ *   - accountingManagers      : Finance-related subjects only, all actions.
+ *   - serviceManagers         : Service/maintenance subjects only, all actions.
+ *   - marketingManagers       : Marketplace and marketing subjects only, all actions.
+ *   - salesAndLeasingManagers : Leasing pipeline subjects only, all actions.
+ *
+ * ## Arabic translation map
+ * TODO: Arabic review — all name_ar values below are literal/translated by map and must
+ * be reviewed by a native Arabic speaker before this seeder merges to production.
+ */
+class RbacSeeder extends Seeder
+{
+    /** @var array<string, string> Arabic noun labels keyed by PermissionSubject::value */
+    private const SUBJECT_AR = [
+        'communities' => 'المجتمعات',
+        'buildings' => 'المباني',
+        'units' => 'الوحدات',
+        'leases' => 'عقود الإيجار',
+        'subLeases' => 'عقود الإيجار الفرعية',
+        'transactions' => 'المعاملات',
+        'payments' => 'المدفوعات',
+        'owners' => 'الملاك',
+        'tenants' => 'المستأجرون',
+        'dependents' => 'المعالون',
+        'admins' => 'المسؤولون',
+        'professionals' => 'المهنيون',
+        'homeServices' => 'الخدمات المنزلية',
+        'neighbourhoodServices' => 'خدمات الحي',
+        'visitorAccess' => 'دخول الزوار',
+        'facilityBookings' => 'حجوزات المرافق',
+        'managerRequests' => 'طلبات المدير',
+        'facilities' => 'المرافق',
+        'announcements' => 'الإعلانات',
+        'directories' => 'الأدلة',
+        'suggestions' => 'الاقتراحات',
+        'complaints' => 'الشكاوى',
+        'marketPlaces' => 'الأسواق',
+        'marketPlaceBookings' => 'حجوزات الأسواق',
+        'marketPlaceVisits' => 'زيارات الأسواق',
+        'offerRequests' => 'طلبات العروض',
+        'reports' => 'التقارير',
+        'settings' => 'الإعدادات',
+        'companyProfile' => 'ملف الشركة',
+        'invoiceSettings' => 'إعدادات الفواتير',
+        'leaseSettings' => 'إعدادات الإيجار',
+    ];
+
+    /** @var array<string, string> Arabic verb labels keyed by PermissionAction::value */
+    private const ACTION_AR = [
+        'VIEW' => 'عرض',
+        'CREATE' => 'إنشاء',
+        'UPDATE' => 'تعديل',
+        'DELETE' => 'حذف',
+        'RESTORE' => 'استعادة',
+        'FORCE_DELETE' => 'حذف نهائي',
+    ];
+
+    /** @var array<string, string> English verb labels keyed by PermissionAction::value */
+    private const ACTION_EN = [
+        'VIEW' => 'View',
+        'CREATE' => 'Create',
+        'UPDATE' => 'Update',
+        'DELETE' => 'Delete',
+        'RESTORE' => 'Restore',
+        'FORCE_DELETE' => 'Force Delete',
+    ];
+
+    public function run(): void
+    {
+        app(PermissionRegistrar::class)->forgetCachedPermissions();
+
+        DB::transaction(function () {
+            $allNames = $this->seedPermissions();
+            $this->deleteOrphanedSystemPermissions($allNames);
+            $this->seedRoles();
+            $this->syncRolePermissions();
+        });
+
+        app(PermissionRegistrar::class)->forgetCachedPermissions();
+    }
+
+    /** @return list<string> All 186 permission names created/updated */
+    private function seedPermissions(): array
+    {
+        $allNames = [];
+
+        foreach (PermissionSubject::cases() as $subject) {
+            foreach (PermissionAction::cases() as $action) {
+                $name = "{$subject->value}.{$action->value}";
+                $allNames[] = $name;
+
+                Permission::withoutGlobalScopes()->updateOrCreate(
+                    ['name' => $name, 'guard_name' => 'web'],
+                    [
+                        'subject' => $subject->value,
+                        'action' => $action->value,
+                        'name_en' => $this->makeNameEn($subject, $action),
+                        'name_ar' => $this->makeNameAr($subject, $action),
+                        'account_tenant_id' => null,
+                    ]
+                );
+            }
+        }
+
+        return $allNames;
+    }
+
+    /** @param list<string> $allNames */
+    private function deleteOrphanedSystemPermissions(array $allNames): void
+    {
+        Permission::withoutGlobalScopes()
+            ->whereNull('account_tenant_id')
+            ->whereNotIn('name', $allNames)
+            ->delete();
+    }
+
+    private function seedRoles(): void
+    {
+        $roles = [
+            // UserRole defaults
+            [
+                'name' => 'accountAdmins',
+                'type' => RoleType::UserRole,
+                'name_en' => 'Account Admin',
+                'name_ar' => 'مسؤول الحساب',
+            ],
+            [
+                'name' => 'admins',
+                'type' => RoleType::UserRole,
+                'name_en' => 'Admin',
+                'name_ar' => 'مسؤول',
+            ],
+            [
+                'name' => 'managers',
+                'type' => RoleType::UserRole,
+                'name_en' => 'Manager',
+                'name_ar' => 'مدير',
+            ],
+            [
+                'name' => 'owners',
+                'type' => RoleType::UserRole,
+                'name_en' => 'Owner',
+                'name_ar' => 'مالك',
+            ],
+            [
+                'name' => 'tenants',
+                'type' => RoleType::UserRole,
+                'name_en' => 'Tenant',
+                'name_ar' => 'مستأجر',
+            ],
+            [
+                'name' => 'dependents',
+                'type' => RoleType::UserRole,
+                'name_en' => 'Dependent',
+                'name_ar' => 'معال',
+            ],
+            [
+                'name' => 'professionals',
+                'type' => RoleType::UserRole,
+                'name_en' => 'Professional',
+                'name_ar' => 'مهني',
+            ],
+            // AdminRole defaults
+            [
+                'name' => 'Admins',
+                'type' => RoleType::AdminRole,
+                'name_en' => 'System Admin',
+                'name_ar' => 'مسؤول النظام',
+            ],
+            [
+                'name' => 'accountingManagers',
+                'type' => RoleType::AdminRole,
+                'name_en' => 'Accounting Manager',
+                'name_ar' => 'مدير الحسابات',
+            ],
+            [
+                'name' => 'serviceManagers',
+                'type' => RoleType::AdminRole,
+                'name_en' => 'Service Manager',
+                'name_ar' => 'مدير الخدمات',
+            ],
+            [
+                'name' => 'marketingManagers',
+                'type' => RoleType::AdminRole,
+                'name_en' => 'Marketing Manager',
+                'name_ar' => 'مدير التسويق',
+            ],
+            [
+                'name' => 'salesAndLeasingManagers',
+                'type' => RoleType::AdminRole,
+                'name_en' => 'Sales & Leasing Manager',
+                'name_ar' => 'مدير المبيعات والإيجار',
+            ],
+        ];
+
+        foreach ($roles as $roleData) {
+            Role::withoutGlobalScopes()->updateOrCreate(
+                [
+                    'name' => $roleData['name'],
+                    'guard_name' => 'web',
+                    'account_tenant_id' => null,
+                ],
+                [
+                    'type' => $roleData['type'],
+                    'name_en' => $roleData['name_en'],
+                    'name_ar' => $roleData['name_ar'],
+                ]
+            );
+        }
+    }
+
+    private function syncRolePermissions(): void
+    {
+        app(PermissionRegistrar::class)->forgetCachedPermissions();
+
+        $allSubjects = PermissionSubject::cases();
+        $allActions = PermissionAction::cases();
+
+        $this->syncRole('accountAdmins', $allSubjects, $allActions);
+
+        $adminSubjects = array_filter(
+            $allSubjects,
+            fn (PermissionSubject $s) => ! in_array($s, [
+                PermissionSubject::CompanyProfile,
+                PermissionSubject::InvoiceSettings,
+                PermissionSubject::LeaseSettings,
+            ])
+        );
+        $this->syncRole('admins', array_values($adminSubjects), $allActions);
+
+        $managerSubjects = [
+            PermissionSubject::Communities,
+            PermissionSubject::Buildings,
+            PermissionSubject::Units,
+            PermissionSubject::Leases,
+            PermissionSubject::Transactions,
+            PermissionSubject::Payments,
+            PermissionSubject::Owners,
+            PermissionSubject::Tenants,
+            PermissionSubject::Dependents,
+            PermissionSubject::Professionals,
+            PermissionSubject::FacilityBookings,
+            PermissionSubject::ManagerRequests,
+            PermissionSubject::Facilities,
+            PermissionSubject::Announcements,
+            PermissionSubject::Directories,
+            PermissionSubject::Suggestions,
+            PermissionSubject::Complaints,
+            PermissionSubject::MarketPlaces,
+            PermissionSubject::MarketPlaceBookings,
+            PermissionSubject::MarketPlaceVisits,
+            PermissionSubject::OfferRequests,
+            PermissionSubject::Reports,
+            PermissionSubject::VisitorAccess,
+            PermissionSubject::HomeServices,
+            PermissionSubject::NeighbourhoodServices,
+        ];
+        $this->syncRole('managers', $managerSubjects, $allActions);
+
+        $ownerSubjects = [
+            PermissionSubject::Units,
+            PermissionSubject::Leases,
+            PermissionSubject::Transactions,
+            PermissionSubject::Payments,
+            PermissionSubject::FacilityBookings,
+            PermissionSubject::Facilities,
+            PermissionSubject::Announcements,
+            PermissionSubject::MarketPlaces,
+            PermissionSubject::MarketPlaceBookings,
+            PermissionSubject::OfferRequests,
+            PermissionSubject::Reports,
+        ];
+        $ownerActions = [
+            PermissionAction::View,
+            PermissionAction::Create,
+            PermissionAction::Update,
+        ];
+        $this->syncRole('owners', $ownerSubjects, $ownerActions);
+
+        $tenantSubjects = [
+            PermissionSubject::Leases,
+            PermissionSubject::Transactions,
+            PermissionSubject::Payments,
+            PermissionSubject::FacilityBookings,
+            PermissionSubject::Facilities,
+            PermissionSubject::Announcements,
+            PermissionSubject::Directories,
+            PermissionSubject::Suggestions,
+            PermissionSubject::Complaints,
+            PermissionSubject::MarketPlaces,
+            PermissionSubject::VisitorAccess,
+            PermissionSubject::HomeServices,
+            PermissionSubject::NeighbourhoodServices,
+        ];
+        $tenantActions = [PermissionAction::View, PermissionAction::Create];
+        $this->syncRole('tenants', $tenantSubjects, $tenantActions);
+
+        $dependentSubjects = [
+            PermissionSubject::Announcements,
+            PermissionSubject::Facilities,
+            PermissionSubject::FacilityBookings,
+        ];
+        $this->syncRole('dependents', $dependentSubjects, [PermissionAction::View]);
+
+        $professionalSubjects = [
+            PermissionSubject::ManagerRequests,
+            PermissionSubject::HomeServices,
+            PermissionSubject::NeighbourhoodServices,
+        ];
+        $professionalActions = [PermissionAction::View, PermissionAction::Update];
+        $this->syncRole('professionals', $professionalSubjects, $professionalActions);
+
+        // AdminRole presets
+        $this->syncRole('Admins', $allSubjects, $allActions);
+
+        $accountingSubjects = [
+            PermissionSubject::Transactions,
+            PermissionSubject::Payments,
+            PermissionSubject::Leases,
+            PermissionSubject::Reports,
+            PermissionSubject::InvoiceSettings,
+            PermissionSubject::LeaseSettings,
+            PermissionSubject::Tenants,
+            PermissionSubject::Owners,
+        ];
+        $this->syncRole('accountingManagers', $accountingSubjects, $allActions);
+
+        $serviceSubjects = [
+            PermissionSubject::ManagerRequests,
+            PermissionSubject::HomeServices,
+            PermissionSubject::NeighbourhoodServices,
+            PermissionSubject::Facilities,
+            PermissionSubject::FacilityBookings,
+            PermissionSubject::Professionals,
+            PermissionSubject::Suggestions,
+            PermissionSubject::Complaints,
+        ];
+        $this->syncRole('serviceManagers', $serviceSubjects, $allActions);
+
+        $marketingSubjects = [
+            PermissionSubject::MarketPlaces,
+            PermissionSubject::MarketPlaceBookings,
+            PermissionSubject::MarketPlaceVisits,
+            PermissionSubject::OfferRequests,
+            PermissionSubject::Announcements,
+            PermissionSubject::Directories,
+        ];
+        $this->syncRole('marketingManagers', $marketingSubjects, $allActions);
+
+        $salesSubjects = [
+            PermissionSubject::Leases,
+            PermissionSubject::SubLeases,
+            PermissionSubject::Units,
+            PermissionSubject::Owners,
+            PermissionSubject::Tenants,
+            PermissionSubject::Transactions,
+            PermissionSubject::Reports,
+            PermissionSubject::LeaseSettings,
+        ];
+        $this->syncRole('salesAndLeasingManagers', $salesSubjects, $allActions);
+    }
+
+    /**
+     * @param  list<PermissionSubject>  $subjects
+     * @param  list<PermissionAction>  $actions
+     */
+    private function syncRole(string $roleName, array $subjects, array $actions): void
+    {
+        $role = Role::withoutGlobalScopes()
+            ->where('name', $roleName)
+            ->where('guard_name', 'web')
+            ->whereNull('account_tenant_id')
+            ->firstOrFail();
+
+        $permissionNames = [];
+        foreach ($subjects as $subject) {
+            foreach ($actions as $action) {
+                $permissionNames[] = "{$subject->value}.{$action->value}";
+            }
+        }
+
+        $permissions = Permission::withoutGlobalScopes()
+            ->whereNull('account_tenant_id')
+            ->whereIn('name', $permissionNames)
+            ->get();
+
+        $role->syncPermissions($permissions);
+    }
+
+    private function makeNameEn(PermissionSubject $subject, PermissionAction $action): string
+    {
+        $verb = self::ACTION_EN[$action->value];
+        $noun = ucfirst(preg_replace('/(?<!^)([A-Z])/', ' $1', $subject->value) ?? $subject->value);
+
+        return "{$verb} {$noun}";
+    }
+
+    private function makeNameAr(PermissionSubject $subject, PermissionAction $action): string
+    {
+        $verb = self::ACTION_AR[$action->value];
+        $noun = self::SUBJECT_AR[$subject->value] ?? $subject->value;
+
+        return "{$verb} {$noun}";
+    }
+}

--- a/tests/Feature/Rbac/RbacSeederTest.php
+++ b/tests/Feature/Rbac/RbacSeederTest.php
@@ -243,6 +243,90 @@ class RbacSeederTest extends TestCase
         $this->assertFalse($hasNonNullTenant, 'All 12 default roles must have account_tenant_id = NULL');
     }
 
+    public function test_deleted_permission_is_recreated_on_reseed(): void
+    {
+        $this->runSeeder();
+
+        Permission::withoutGlobalScopes()
+            ->where('name', 'communities.VIEW')
+            ->whereNull('account_tenant_id')
+            ->delete();
+
+        $this->runSeeder();
+
+        $exists = Permission::withoutGlobalScopes()
+            ->where('name', 'communities.VIEW')
+            ->whereNull('account_tenant_id')
+            ->exists();
+
+        $this->assertTrue($exists, 'Deleted system permission must be recreated on re-seed');
+    }
+
+    public function test_deleted_role_is_recreated_on_reseed(): void
+    {
+        $this->runSeeder();
+
+        Role::withoutGlobalScopes()
+            ->where('name', 'managers')
+            ->whereNull('account_tenant_id')
+            ->delete();
+
+        $this->runSeeder();
+
+        $role = Role::withoutGlobalScopes()
+            ->where('name', 'managers')
+            ->whereNull('account_tenant_id')
+            ->first();
+
+        $this->assertNotNull($role, 'Deleted default role must be recreated on re-seed');
+        $this->assertSame(150, $role->permissions()->count());
+    }
+
+    public function test_all_12_roles_have_at_least_one_permission(): void
+    {
+        $this->runSeeder();
+
+        $roleNames = [
+            'accountAdmins', 'admins', 'managers', 'owners', 'tenants',
+            'dependents', 'professionals', 'Admins', 'accountingManagers',
+            'serviceManagers', 'marketingManagers', 'salesAndLeasingManagers',
+        ];
+
+        foreach ($roleNames as $roleName) {
+            $role = Role::withoutGlobalScopes()
+                ->where('name', $roleName)
+                ->whereNull('account_tenant_id')
+                ->firstOrFail();
+
+            $this->assertGreaterThan(
+                0,
+                $role->permissions()->count(),
+                "Role '{$roleName}' must have at least one permission assigned"
+            );
+        }
+    }
+
+    public function test_all_12_roles_have_valid_type(): void
+    {
+        $this->runSeeder();
+
+        $validTypes = RoleType::cases();
+
+        $roles = Role::withoutGlobalScopes()
+            ->whereNull('account_tenant_id')
+            ->get();
+
+        $this->assertCount(12, $roles);
+
+        foreach ($roles as $role) {
+            $this->assertContains(
+                $role->type,
+                $validTypes,
+                "Role '{$role->name}' has invalid type"
+            );
+        }
+    }
+
     public function test_permission_name_format_is_subject_dot_action(): void
     {
         $this->runSeeder();

--- a/tests/Feature/Rbac/RbacSeederTest.php
+++ b/tests/Feature/Rbac/RbacSeederTest.php
@@ -1,0 +1,262 @@
+<?php
+
+namespace Tests\Feature\Rbac;
+
+use App\Enums\PermissionAction;
+use App\Enums\PermissionSubject;
+use App\Enums\RoleType;
+use App\Models\Permission;
+use App\Models\Role;
+use App\Models\Tenant;
+use Database\Seeders\RbacSeeder;
+use Illuminate\Foundation\Testing\LazilyRefreshDatabase;
+use PHPUnit\Framework\Attributes\DataProvider;
+use Tests\TestCase;
+
+class RbacSeederTest extends TestCase
+{
+    use LazilyRefreshDatabase;
+
+    private function runSeeder(): void
+    {
+        (new RbacSeeder)->run();
+    }
+
+    // ── Happy path ────────────────────────────────────────────────────────────
+
+    public function test_seeder_creates_exactly_186_permissions(): void
+    {
+        $this->runSeeder();
+
+        $count = Permission::withoutGlobalScopes()
+            ->whereNull('account_tenant_id')
+            ->count();
+
+        $this->assertSame(186, $count);
+    }
+
+    public function test_seeder_creates_exactly_12_roles(): void
+    {
+        $this->runSeeder();
+
+        $count = Role::withoutGlobalScopes()
+            ->whereNull('account_tenant_id')
+            ->count();
+
+        $this->assertSame(12, $count);
+    }
+
+    public function test_all_permissions_have_bilingual_names(): void
+    {
+        $this->runSeeder();
+
+        $missing = Permission::withoutGlobalScopes()
+            ->whereNull('account_tenant_id')
+            ->where(function ($q) {
+                $q->whereNull('name_en')
+                    ->orWhere('name_en', '')
+                    ->orWhereNull('name_ar')
+                    ->orWhere('name_ar', '');
+            })
+            ->count();
+
+        $this->assertSame(0, $missing, 'Every permission must have non-empty name_en and name_ar');
+    }
+
+    public function test_all_permissions_have_subject_and_action(): void
+    {
+        $this->runSeeder();
+
+        $missing = Permission::withoutGlobalScopes()
+            ->whereNull('account_tenant_id')
+            ->where(function ($q) {
+                $q->whereNull('subject')->orWhereNull('action');
+            })
+            ->count();
+
+        $this->assertSame(0, $missing, 'Every permission must have subject and action set');
+    }
+
+    public function test_account_admin_has_all_186_permissions(): void
+    {
+        $this->runSeeder();
+
+        $role = Role::withoutGlobalScopes()
+            ->where('name', 'accountAdmins')
+            ->whereNull('account_tenant_id')
+            ->firstOrFail();
+
+        $this->assertSame(186, $role->permissions()->count());
+    }
+
+    // ── Per-role permission count ranges ─────────────────────────────────────
+
+    #[DataProvider('rolePermissionCounts')]
+    public function test_each_role_has_expected_permission_count(string $roleName, int $expectedCount): void
+    {
+        $this->runSeeder();
+
+        $role = Role::withoutGlobalScopes()
+            ->where('name', $roleName)
+            ->whereNull('account_tenant_id')
+            ->firstOrFail();
+
+        $this->assertSame(
+            $expectedCount,
+            $role->permissions()->count(),
+            "Role '{$roleName}' has unexpected permission count"
+        );
+    }
+
+    /** @return array<string, array{string, int}> */
+    public static function rolePermissionCounts(): array
+    {
+        // accountAdmins: 31×6 = 186
+        // admins: (31-3)×6 = 28×6 = 168
+        // managers: 25 subjects × 6 = 150
+        // owners: 11 subjects × 3 actions = 33
+        // tenants: 13 subjects × 2 actions = 26
+        // dependents: 3 subjects × 1 action = 3
+        // professionals: 3 subjects × 2 actions = 6
+        // Admins (AdminRole): 31×6 = 186
+        // accountingManagers: 8 subjects × 6 = 48
+        // serviceManagers: 8 subjects × 6 = 48
+        // marketingManagers: 6 subjects × 6 = 36
+        // salesAndLeasingManagers: 8 subjects × 6 = 48
+        return [
+            'accountAdmins' => ['accountAdmins', 186],
+            'admins' => ['admins', 168],
+            'managers' => ['managers', 150],
+            'owners' => ['owners', 33],
+            'tenants' => ['tenants', 26],
+            'dependents' => ['dependents', 3],
+            'professionals' => ['professionals', 6],
+            'Admins' => ['Admins', 186],
+            'accountingManagers' => ['accountingManagers', 48],
+            'serviceManagers' => ['serviceManagers', 48],
+            'marketingManagers' => ['marketingManagers', 36],
+            'salesAndLeasingManagers' => ['salesAndLeasingManagers', 48],
+        ];
+    }
+
+    // ── Idempotency ───────────────────────────────────────────────────────────
+
+    public function test_running_seeder_twice_does_not_duplicate_permissions(): void
+    {
+        $this->runSeeder();
+        $this->runSeeder();
+
+        $count = Permission::withoutGlobalScopes()
+            ->whereNull('account_tenant_id')
+            ->count();
+
+        $this->assertSame(186, $count);
+    }
+
+    public function test_running_seeder_twice_does_not_duplicate_roles(): void
+    {
+        $this->runSeeder();
+        $this->runSeeder();
+
+        $count = Role::withoutGlobalScopes()
+            ->whereNull('account_tenant_id')
+            ->count();
+
+        $this->assertSame(12, $count);
+    }
+
+    // ── Orphan reconciliation ─────────────────────────────────────────────────
+
+    public function test_orphaned_system_permissions_are_removed_on_rerun(): void
+    {
+        // Insert a stale system-wide permission not in the 186-member set
+        Permission::withoutGlobalScopes()->create([
+            'name' => 'staleSubject.VIEW',
+            'guard_name' => 'web',
+            'account_tenant_id' => null,
+        ]);
+
+        $this->runSeeder();
+
+        $exists = Permission::withoutGlobalScopes()
+            ->whereNull('account_tenant_id')
+            ->where('name', 'staleSubject.VIEW')
+            ->exists();
+
+        $this->assertFalse($exists, 'Stale system permission should be deleted by seeder');
+    }
+
+    public function test_tenant_custom_permissions_are_not_removed(): void
+    {
+        // Create a tenant and a custom permission scoped to it
+        $tenant = Tenant::query()->create(['name' => 'Test Tenant']);
+
+        Permission::withoutGlobalScopes()->create([
+            'name' => 'customSubject.VIEW',
+            'guard_name' => 'web',
+            'account_tenant_id' => $tenant->id,
+        ]);
+
+        $this->runSeeder();
+
+        $exists = Permission::withoutGlobalScopes()
+            ->where('account_tenant_id', $tenant->id)
+            ->where('name', 'customSubject.VIEW')
+            ->exists();
+
+        $this->assertTrue($exists, 'Tenant-scoped custom permission must not be deleted');
+    }
+
+    // ── Edge cases ────────────────────────────────────────────────────────────
+
+    public function test_roles_have_correct_type(): void
+    {
+        $this->runSeeder();
+
+        $userRole = Role::withoutGlobalScopes()
+            ->where('name', 'accountAdmins')
+            ->whereNull('account_tenant_id')
+            ->firstOrFail();
+
+        $adminRole = Role::withoutGlobalScopes()
+            ->where('name', 'Admins')
+            ->whereNull('account_tenant_id')
+            ->firstOrFail();
+
+        $this->assertSame(RoleType::UserRole, $userRole->type);
+        $this->assertSame(RoleType::AdminRole, $adminRole->type);
+    }
+
+    public function test_roles_have_null_account_tenant_id(): void
+    {
+        $this->runSeeder();
+
+        $hasNonNullTenant = Role::withoutGlobalScopes()
+            ->whereIn('name', [
+                'accountAdmins', 'admins', 'managers', 'owners', 'tenants',
+                'dependents', 'professionals', 'Admins', 'accountingManagers',
+                'serviceManagers', 'marketingManagers', 'salesAndLeasingManagers',
+            ])
+            ->whereNotNull('account_tenant_id')
+            ->exists();
+
+        $this->assertFalse($hasNonNullTenant, 'All 12 default roles must have account_tenant_id = NULL');
+    }
+
+    public function test_permission_name_format_is_subject_dot_action(): void
+    {
+        $this->runSeeder();
+
+        // Spot-check a known permission
+        $permission = Permission::withoutGlobalScopes()
+            ->where('name', 'communities.VIEW')
+            ->whereNull('account_tenant_id')
+            ->first();
+
+        $this->assertNotNull($permission);
+        $this->assertSame(PermissionSubject::Communities, $permission->subject);
+        $this->assertSame(PermissionAction::View, $permission->action);
+        $this->assertNotEmpty($permission->name_en);
+        $this->assertNotEmpty($permission->name_ar);
+    }
+}


### PR DESCRIPTION
Closes #111

## Summary
- Adds `RbacSeeder` that generates 186 system-wide permissions (31 `PermissionSubject` × 6 `PermissionAction`) with bilingual `name_en`/`name_ar`, and 12 default roles (7 `UserRole` + 5 `AdminRole`) with permission presets via `syncPermissions`.
- Adds a migration for `name_en`, `name_ar`, and `account_tenant_id` columns on the `permissions` table (these were missing from the #110 schema — `extend_permissions_table` only added `subject`/`action`).
- Seeder is fully idempotent (`updateOrCreate` throughout), orphan-reconciling (deletes stale system-wide permissions), and atomic (wrapped in `DB::transaction`).
- Replaces `RolesSeeder` reference in `DemoAccountSeeder` with `RbacSeeder`; wires `RbacSeeder` into `DatabaseSeeder`.

## Files changed
- `database/migrations/2026_04_23_101408_add_bilingual_and_tenant_columns_to_permissions_table.php` — new migration
- `database/seeders/RbacSeeder.php` — new seeder (replaces old RolesSeeder + PermissionsSeeder responsibilities)
- `database/seeders/DatabaseSeeder.php` — calls `RbacSeeder` before `DemoAccountSeeder`
- `database/seeders/DemoAccountSeeder.php` — replaces `RolesSeeder::class` with `RbacSeeder::class`
- `tests/Feature/Rbac/RbacSeederTest.php` — 24 tests covering happy path, idempotency, orphan reconciliation, edge cases

## Notes
- `PermissionsSeeder.php` and `RolesSeeder.php` are left in place (not deleted) — they are now unreferenced but removal can be a follow-up to avoid noise in this PR.
- **Arabic review required:** All `name_ar` values are computed from a static map and annotated with `TODO: Arabic review` in the seeder docblock. This must be reviewed by a native speaker before production merge.
- Permission presets document their rationale in the seeder class docblock.

## Test plan
- [x] PHPUnit: `php artisan test --compact tests/Feature/Rbac/RbacSeederTest.php` — 24 passed
- [x] Pint clean
- [ ] Manual UI check (QA)