### PR TITLE
feat: manager scope — forManager() local scope + policy enforcement on 16 models (#113)

### DIFF
--- a/app/Concerns/HasManagerScope.php
+++ b/app/Concerns/HasManagerScope.php
@@ -1,0 +1,82 @@
+<?php
+
+namespace App\Concerns;
+
+use App\Models\User;
+use App\Support\ManagerScopeHelper;
+use Illuminate\Database\Eloquent\Builder;
+
+/**
+ * Provides the `forManager(User $user)` local Eloquent scope.
+ *
+ * Models that use this trait expose a `scopeForManager` method that controllers
+ * opt into explicitly:
+ *
+ *   Model::query()->forManager(auth()->user())->paginate()
+ *
+ * Each model may override `scopeForManager` to implement a custom join path.
+ * The default implementation handles models with direct `community_id` /
+ * `building_id` columns. Override as needed.
+ *
+ * accountAdmins and system-wide roles are short-circuited via
+ * ManagerScopeHelper::scopesForUser() returning is_unrestricted=true, in which
+ * case this scope adds no WHERE clauses.
+ */
+trait HasManagerScope
+{
+    /**
+     * Scope the query to records the given manager user is allowed to see.
+     *
+     * @param  Builder<static>  $query
+     * @return Builder<static>
+     */
+    public function scopeForManager(Builder $query, User $user): Builder
+    {
+        $scopes = ManagerScopeHelper::scopesForUser($user);
+
+        if ($scopes['is_unrestricted']) {
+            return $query;
+        }
+
+        $communityIds = $scopes['community_ids'];
+        $buildingIds = $scopes['building_ids'];
+
+        return $query->where(function (Builder $q) use ($communityIds, $buildingIds): void {
+            $hasFilter = false;
+
+            if (! empty($communityIds) && $this->hasCommunityIdColumn()) {
+                $q->orWhereIn($this->getTable().'.community_id', $communityIds);
+                $hasFilter = true;
+            }
+
+            if (! empty($buildingIds) && $this->hasBuildingIdColumn()) {
+                $q->orWhereIn($this->getTable().'.building_id', $buildingIds);
+                $hasFilter = true;
+            }
+
+            // If neither filter applies, return nothing (scope columns set but
+            // this model has no matching FK — safety net).
+            if (! $hasFilter) {
+                $q->whereRaw('1 = 0');
+            }
+        });
+    }
+
+    /**
+     * Whether this model's table has a `community_id` column for filtering.
+     * Override to return false if not applicable.
+     */
+    protected function hasCommunityIdColumn(): bool
+    {
+        return true;
+    }
+
+    /**
+     * Whether this model's table has a `building_id` column for filtering.
+     * Override to return false if not applicable.
+     */
+    protected function hasBuildingIdColumn(): bool
+    {
+        return false;
+    }
+}

--- a/app/Models/Announcement.php
+++ b/app/Models/Announcement.php
@@ -3,6 +3,7 @@
 namespace App\Models;
 
 use App\Concerns\BelongsToAccountTenant;
+use App\Concerns\HasManagerScope;
 use Database\Factories\AnnouncementFactory;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
@@ -12,9 +13,14 @@ use Illuminate\Database\Eloquent\SoftDeletes;
 class Announcement extends Model
 {
     /** @use HasFactory<AnnouncementFactory> */
-    use BelongsToAccountTenant, HasFactory, SoftDeletes;
+    use BelongsToAccountTenant, HasFactory, HasManagerScope, SoftDeletes;
 
     protected $table = 'rf_announcements';
+
+    protected function hasBuildingIdColumn(): bool
+    {
+        return true;
+    }
 
     protected $fillable = [
         'community_id',

--- a/app/Models/Building.php
+++ b/app/Models/Building.php
@@ -3,7 +3,10 @@
 namespace App\Models;
 
 use App\Concerns\BelongsToAccountTenant;
+use App\Concerns\HasManagerScope;
+use App\Support\ManagerScopeHelper;
 use Database\Factories\BuildingFactory;
+use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
@@ -13,7 +16,38 @@ use Illuminate\Database\Eloquent\Relations\MorphMany;
 class Building extends Model
 {
     /** @use HasFactory<BuildingFactory> */
-    use BelongsToAccountTenant, HasFactory;
+    use BelongsToAccountTenant, HasFactory, HasManagerScope;
+
+    /**
+     * Buildings: match by direct building_id OR via community (rf_community_id).
+     *
+     * @param  Builder<static>  $query
+     * @return Builder<static>
+     */
+    public function scopeForManager(Builder $query, User $user): Builder
+    {
+        $scopes = ManagerScopeHelper::scopesForUser($user);
+
+        if ($scopes['is_unrestricted']) {
+            return $query;
+        }
+
+        $communityIds = $scopes['community_ids'];
+        $buildingIds = $scopes['building_ids'];
+
+        if (empty($communityIds) && empty($buildingIds)) {
+            return $query->whereRaw('1 = 0');
+        }
+
+        return $query->where(function (Builder $q) use ($communityIds, $buildingIds): void {
+            if (! empty($buildingIds)) {
+                $q->orWhereIn($this->getTable().'.id', $buildingIds);
+            }
+            if (! empty($communityIds)) {
+                $q->orWhereIn($this->getTable().'.rf_community_id', $communityIds);
+            }
+        });
+    }
 
     protected $table = 'rf_buildings';
 

--- a/app/Models/Community.php
+++ b/app/Models/Community.php
@@ -3,8 +3,11 @@
 namespace App\Models;
 
 use App\Concerns\BelongsToAccountTenant;
+use App\Concerns\HasManagerScope;
 use App\Enums\MarketplaceType;
+use App\Support\ManagerScopeHelper;
 use Database\Factories\CommunityFactory;
+use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
@@ -15,7 +18,30 @@ use Illuminate\Database\Eloquent\Relations\MorphMany;
 class Community extends Model
 {
     /** @use HasFactory<CommunityFactory> */
-    use BelongsToAccountTenant, HasFactory;
+    use BelongsToAccountTenant, HasFactory, HasManagerScope;
+
+    /**
+     * Community is filtered by its own ID (not a community_id FK column).
+     *
+     * @param  Builder<static>  $query
+     * @return Builder<static>
+     */
+    public function scopeForManager(Builder $query, User $user): Builder
+    {
+        $scopes = ManagerScopeHelper::scopesForUser($user);
+
+        if ($scopes['is_unrestricted']) {
+            return $query;
+        }
+
+        $communityIds = $scopes['community_ids'];
+
+        if (empty($communityIds)) {
+            return $query->whereRaw('1 = 0');
+        }
+
+        return $query->whereIn($this->getTable().'.id', $communityIds);
+    }
 
     protected $table = 'rf_communities';
 

--- a/app/Models/Facility.php
+++ b/app/Models/Facility.php
@@ -4,6 +4,7 @@ namespace App\Models;
 
 use App\Concerns\BelongsToAccountTenant;
 use App\Concerns\HasBilingualName;
+use App\Concerns\HasManagerScope;
 use Database\Factories\FacilityFactory;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
@@ -14,7 +15,7 @@ use Illuminate\Database\Eloquent\SoftDeletes;
 class Facility extends Model
 {
     /** @use HasFactory<FacilityFactory> */
-    use BelongsToAccountTenant, HasBilingualName, HasFactory, SoftDeletes;
+    use BelongsToAccountTenant, HasBilingualName, HasFactory, HasManagerScope, SoftDeletes;
 
     protected $table = 'rf_facilities';
 

--- a/app/Models/FacilityBooking.php
+++ b/app/Models/FacilityBooking.php
@@ -2,7 +2,10 @@
 
 namespace App\Models;
 
+use App\Concerns\HasManagerScope;
+use App\Support\ManagerScopeHelper;
 use Database\Factories\FacilityBookingFactory;
+use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
@@ -12,9 +15,38 @@ use Illuminate\Database\Eloquent\SoftDeletes;
 class FacilityBooking extends Model
 {
     /** @use HasFactory<FacilityBookingFactory> */
-    use HasFactory, SoftDeletes;
+    use HasFactory, HasManagerScope, SoftDeletes;
 
     protected $table = 'rf_facility_bookings';
+
+    /**
+     * FacilityBookings: filter via facility_id → rf_facilities.community_id.
+     *
+     * @param  Builder<static>  $query
+     * @return Builder<static>
+     */
+    public function scopeForManager(Builder $query, User $user): Builder
+    {
+        $scopes = ManagerScopeHelper::scopesForUser($user);
+
+        if ($scopes['is_unrestricted']) {
+            return $query;
+        }
+
+        $communityIds = $scopes['community_ids'];
+
+        if (empty($communityIds)) {
+            return $query->whereRaw('1 = 0');
+        }
+
+        return $query->whereIn(
+            $this->getTable().'.facility_id',
+            fn ($sub) => $sub
+                ->select('id')
+                ->from('rf_facilities')
+                ->whereIn('community_id', $communityIds)
+        );
+    }
 
     protected $fillable = [
         'facility_id',

--- a/app/Models/Lease.php
+++ b/app/Models/Lease.php
@@ -3,10 +3,13 @@
 namespace App\Models;
 
 use App\Concerns\BelongsToAccountTenant;
+use App\Concerns\HasManagerScope;
 use App\Enums\LeaseEscalationType;
 use App\Enums\RentalType;
 use App\Enums\TenantType;
+use App\Support\ManagerScopeHelper;
 use Database\Factories\LeaseFactory;
+use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
@@ -17,9 +20,47 @@ use Illuminate\Database\Eloquent\SoftDeletes;
 class Lease extends Model
 {
     /** @use HasFactory<LeaseFactory> */
-    use BelongsToAccountTenant, HasFactory, SoftDeletes;
+    use BelongsToAccountTenant, HasFactory, HasManagerScope, SoftDeletes;
 
     protected $table = 'rf_leases';
+
+    /**
+     * Leases: filter via lease_units pivot → rf_units community/building FK.
+     *
+     * @param  Builder<static>  $query
+     * @return Builder<static>
+     */
+    public function scopeForManager(Builder $query, User $user): Builder
+    {
+        $scopes = ManagerScopeHelper::scopesForUser($user);
+
+        if ($scopes['is_unrestricted']) {
+            return $query;
+        }
+
+        $communityIds = $scopes['community_ids'];
+        $buildingIds = $scopes['building_ids'];
+
+        if (empty($communityIds) && empty($buildingIds)) {
+            return $query->whereRaw('1 = 0');
+        }
+
+        return $query->whereIn(
+            $this->getTable().'.id',
+            fn ($sub) => $sub
+                ->select('lease_units.lease_id')
+                ->from('lease_units')
+                ->join('rf_units', 'rf_units.id', '=', 'lease_units.unit_id')
+                ->where(function ($q) use ($communityIds, $buildingIds): void {
+                    if (! empty($communityIds)) {
+                        $q->orWhereIn('rf_units.rf_community_id', $communityIds);
+                    }
+                    if (! empty($buildingIds)) {
+                        $q->orWhereIn('rf_units.rf_building_id', $buildingIds);
+                    }
+                })
+        );
+    }
 
     protected $fillable = [
         'contract_number',

--- a/app/Models/MarketplaceOffer.php
+++ b/app/Models/MarketplaceOffer.php
@@ -3,7 +3,10 @@
 namespace App\Models;
 
 use App\Concerns\BelongsToAccountTenant;
+use App\Concerns\HasManagerScope;
+use App\Support\ManagerScopeHelper;
 use Database\Factories\MarketplaceOfferFactory;
+use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
@@ -11,9 +14,46 @@ use Illuminate\Database\Eloquent\Relations\BelongsTo;
 class MarketplaceOffer extends Model
 {
     /** @use HasFactory<MarketplaceOfferFactory> */
-    use BelongsToAccountTenant, HasFactory;
+    use BelongsToAccountTenant, HasFactory, HasManagerScope;
 
     protected $table = 'rf_marketplace_offers';
+
+    /**
+     * MarketplaceOffers: filter via unit_id → rf_units community/building FK.
+     *
+     * @param  Builder<static>  $query
+     * @return Builder<static>
+     */
+    public function scopeForManager(Builder $query, User $user): Builder
+    {
+        $scopes = ManagerScopeHelper::scopesForUser($user);
+
+        if ($scopes['is_unrestricted']) {
+            return $query;
+        }
+
+        $communityIds = $scopes['community_ids'];
+        $buildingIds = $scopes['building_ids'];
+
+        if (empty($communityIds) && empty($buildingIds)) {
+            return $query->whereRaw('1 = 0');
+        }
+
+        return $query->whereIn(
+            $this->getTable().'.unit_id',
+            fn ($sub) => $sub
+                ->select('id')
+                ->from('rf_units')
+                ->where(function ($q) use ($communityIds, $buildingIds): void {
+                    if (! empty($communityIds)) {
+                        $q->orWhereIn('rf_community_id', $communityIds);
+                    }
+                    if (! empty($buildingIds)) {
+                        $q->orWhereIn('rf_building_id', $buildingIds);
+                    }
+                })
+        );
+    }
 
     protected $fillable = [
         'unit_id',

--- a/app/Models/MarketplaceUnit.php
+++ b/app/Models/MarketplaceUnit.php
@@ -2,7 +2,10 @@
 
 namespace App\Models;
 
+use App\Concerns\HasManagerScope;
+use App\Support\ManagerScopeHelper;
 use Database\Factories\MarketplaceUnitFactory;
+use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
@@ -11,9 +14,46 @@ use Illuminate\Database\Eloquent\Relations\HasMany;
 class MarketplaceUnit extends Model
 {
     /** @use HasFactory<MarketplaceUnitFactory> */
-    use HasFactory;
+    use HasFactory, HasManagerScope;
 
     protected $table = 'rf_marketplace_units';
+
+    /**
+     * MarketplaceUnits: filter via unit_id → rf_units community/building FK.
+     *
+     * @param  Builder<static>  $query
+     * @return Builder<static>
+     */
+    public function scopeForManager(Builder $query, User $user): Builder
+    {
+        $scopes = ManagerScopeHelper::scopesForUser($user);
+
+        if ($scopes['is_unrestricted']) {
+            return $query;
+        }
+
+        $communityIds = $scopes['community_ids'];
+        $buildingIds = $scopes['building_ids'];
+
+        if (empty($communityIds) && empty($buildingIds)) {
+            return $query->whereRaw('1 = 0');
+        }
+
+        return $query->whereIn(
+            $this->getTable().'.unit_id',
+            fn ($sub) => $sub
+                ->select('id')
+                ->from('rf_units')
+                ->where(function ($q) use ($communityIds, $buildingIds): void {
+                    if (! empty($communityIds)) {
+                        $q->orWhereIn('rf_community_id', $communityIds);
+                    }
+                    if (! empty($buildingIds)) {
+                        $q->orWhereIn('rf_building_id', $buildingIds);
+                    }
+                })
+        );
+    }
 
     protected $fillable = [
         'unit_id',

--- a/app/Models/MarketplaceVisit.php
+++ b/app/Models/MarketplaceVisit.php
@@ -2,7 +2,10 @@
 
 namespace App\Models;
 
+use App\Concerns\HasManagerScope;
+use App\Support\ManagerScopeHelper;
 use Database\Factories\MarketplaceVisitFactory;
+use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
@@ -10,9 +13,47 @@ use Illuminate\Database\Eloquent\Relations\BelongsTo;
 class MarketplaceVisit extends Model
 {
     /** @use HasFactory<MarketplaceVisitFactory> */
-    use HasFactory;
+    use HasFactory, HasManagerScope;
 
     protected $table = 'rf_marketplace_visits';
+
+    /**
+     * MarketplaceVisits: filter via marketplace_unit_id → rf_marketplace_units.unit_id → rf_units.
+     *
+     * @param  Builder<static>  $query
+     * @return Builder<static>
+     */
+    public function scopeForManager(Builder $query, User $user): Builder
+    {
+        $scopes = ManagerScopeHelper::scopesForUser($user);
+
+        if ($scopes['is_unrestricted']) {
+            return $query;
+        }
+
+        $communityIds = $scopes['community_ids'];
+        $buildingIds = $scopes['building_ids'];
+
+        if (empty($communityIds) && empty($buildingIds)) {
+            return $query->whereRaw('1 = 0');
+        }
+
+        return $query->whereIn(
+            $this->getTable().'.marketplace_unit_id',
+            fn ($sub) => $sub
+                ->select('rf_marketplace_units.id')
+                ->from('rf_marketplace_units')
+                ->join('rf_units', 'rf_units.id', '=', 'rf_marketplace_units.unit_id')
+                ->where(function ($q) use ($communityIds, $buildingIds): void {
+                    if (! empty($communityIds)) {
+                        $q->orWhereIn('rf_units.rf_community_id', $communityIds);
+                    }
+                    if (! empty($buildingIds)) {
+                        $q->orWhereIn('rf_units.rf_building_id', $buildingIds);
+                    }
+                })
+        );
+    }
 
     protected $fillable = [
         'marketplace_unit_id',

--- a/app/Models/Owner.php
+++ b/app/Models/Owner.php
@@ -4,7 +4,10 @@ namespace App\Models;
 
 use App\Concerns\BelongsToAccountTenant;
 use App\Concerns\HasContactInfo;
+use App\Concerns\HasManagerScope;
+use App\Support\ManagerScopeHelper;
 use Database\Factories\OwnerFactory;
+use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\HasMany;
@@ -14,9 +17,47 @@ use Illuminate\Database\Eloquent\SoftDeletes;
 class Owner extends Model
 {
     /** @use HasFactory<OwnerFactory> */
-    use BelongsToAccountTenant, HasContactInfo, HasFactory, SoftDeletes;
+    use BelongsToAccountTenant, HasContactInfo, HasFactory, HasManagerScope, SoftDeletes;
 
     protected $table = 'rf_owners';
+
+    /**
+     * Owners: filter via rf_units.owner_id → community/building FK.
+     *
+     * @param  Builder<static>  $query
+     * @return Builder<static>
+     */
+    public function scopeForManager(Builder $query, User $user): Builder
+    {
+        $scopes = ManagerScopeHelper::scopesForUser($user);
+
+        if ($scopes['is_unrestricted']) {
+            return $query;
+        }
+
+        $communityIds = $scopes['community_ids'];
+        $buildingIds = $scopes['building_ids'];
+
+        if (empty($communityIds) && empty($buildingIds)) {
+            return $query->whereRaw('1 = 0');
+        }
+
+        return $query->whereIn(
+            $this->getTable().'.id',
+            fn ($sub) => $sub
+                ->select('owner_id')
+                ->from('rf_units')
+                ->whereNotNull('owner_id')
+                ->where(function ($q) use ($communityIds, $buildingIds): void {
+                    if (! empty($communityIds)) {
+                        $q->orWhereIn('rf_community_id', $communityIds);
+                    }
+                    if (! empty($buildingIds)) {
+                        $q->orWhereIn('rf_building_id', $buildingIds);
+                    }
+                })
+        );
+    }
 
     protected $fillable = [
         'first_name',

--- a/app/Models/Payment.php
+++ b/app/Models/Payment.php
@@ -2,7 +2,10 @@
 
 namespace App\Models;
 
+use App\Concerns\HasManagerScope;
+use App\Support\ManagerScopeHelper;
 use Database\Factories\PaymentFactory;
+use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
@@ -11,9 +14,47 @@ use Illuminate\Database\Eloquent\SoftDeletes;
 class Payment extends Model
 {
     /** @use HasFactory<PaymentFactory> */
-    use HasFactory, SoftDeletes;
+    use HasFactory, HasManagerScope, SoftDeletes;
 
     protected $table = 'rf_payments';
+
+    /**
+     * Payments: filter via transaction_id → rf_transactions.unit_id → rf_units.
+     *
+     * @param  Builder<static>  $query
+     * @return Builder<static>
+     */
+    public function scopeForManager(Builder $query, User $user): Builder
+    {
+        $scopes = ManagerScopeHelper::scopesForUser($user);
+
+        if ($scopes['is_unrestricted']) {
+            return $query;
+        }
+
+        $communityIds = $scopes['community_ids'];
+        $buildingIds = $scopes['building_ids'];
+
+        if (empty($communityIds) && empty($buildingIds)) {
+            return $query->whereRaw('1 = 0');
+        }
+
+        return $query->whereIn(
+            $this->getTable().'.transaction_id',
+            fn ($sub) => $sub
+                ->select('rf_transactions.id')
+                ->from('rf_transactions')
+                ->join('rf_units', 'rf_units.id', '=', 'rf_transactions.unit_id')
+                ->where(function ($q) use ($communityIds, $buildingIds): void {
+                    if (! empty($communityIds)) {
+                        $q->orWhereIn('rf_units.rf_community_id', $communityIds);
+                    }
+                    if (! empty($buildingIds)) {
+                        $q->orWhereIn('rf_units.rf_building_id', $buildingIds);
+                    }
+                })
+        );
+    }
 
     protected $fillable = [
         'transaction_id',

--- a/app/Models/Professional.php
+++ b/app/Models/Professional.php
@@ -29,7 +29,11 @@ class Professional extends Model
      */
     public function scopeForManager(Builder $query, User $user): Builder
     {
-        // intentionally unrestricted — no FK path available in schema
+        /**
+         * Intentionally unrestricted: no FK path from professionals
+         * to communities or buildings exists in the current schema.
+         * All managers within the tenant see all professionals.
+         */
         return $query;
     }
 

--- a/app/Models/Professional.php
+++ b/app/Models/Professional.php
@@ -3,7 +3,9 @@
 namespace App\Models;
 
 use App\Concerns\BelongsToAccountTenant;
+use App\Concerns\HasManagerScope;
 use Database\Factories\ProfessionalFactory;
+use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsToMany;
@@ -12,9 +14,24 @@ use Illuminate\Database\Eloquent\Relations\HasMany;
 class Professional extends Model
 {
     /** @use HasFactory<ProfessionalFactory> */
-    use BelongsToAccountTenant, HasFactory;
+    use BelongsToAccountTenant, HasFactory, HasManagerScope;
 
     protected $table = 'rf_professionals';
+
+    /**
+     * Professionals: no direct community/service-type FK exists in the schema.
+     * The service_type path via professional_subcategories → rf_request_subcategories
+     * → service_manager_type_id does not exist in the current schema.
+     * Until a schema linkage is added, all managers see all professionals within tenant.
+     *
+     * @param  Builder<static>  $query
+     * @return Builder<static>
+     */
+    public function scopeForManager(Builder $query, User $user): Builder
+    {
+        // intentionally unrestricted — no FK path available in schema
+        return $query;
+    }
 
     protected $fillable = [
         'first_name',

--- a/app/Models/Request.php
+++ b/app/Models/Request.php
@@ -3,6 +3,7 @@
 namespace App\Models;
 
 use App\Concerns\BelongsToAccountTenant;
+use App\Concerns\HasManagerScope;
 use Database\Factories\RequestFactory;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
@@ -13,9 +14,14 @@ use Illuminate\Database\Eloquent\SoftDeletes;
 class Request extends Model
 {
     /** @use HasFactory<RequestFactory> */
-    use BelongsToAccountTenant, HasFactory, SoftDeletes;
+    use BelongsToAccountTenant, HasFactory, HasManagerScope, SoftDeletes;
 
     protected $table = 'rf_requests';
+
+    protected function hasBuildingIdColumn(): bool
+    {
+        return true;
+    }
 
     protected $fillable = [
         'category_id',

--- a/app/Models/Resident.php
+++ b/app/Models/Resident.php
@@ -4,7 +4,10 @@ namespace App\Models;
 
 use App\Concerns\BelongsToAccountTenant;
 use App\Concerns\HasContactInfo;
+use App\Concerns\HasManagerScope;
+use App\Support\ManagerScopeHelper;
 use Database\Factories\ResidentFactory;
+use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\HasMany;
@@ -14,9 +17,49 @@ use Illuminate\Database\Eloquent\SoftDeletes;
 class Resident extends Model
 {
     /** @use HasFactory<ResidentFactory> */
-    use BelongsToAccountTenant, HasContactInfo, HasFactory, SoftDeletes;
+    use BelongsToAccountTenant, HasContactInfo, HasFactory, HasManagerScope, SoftDeletes;
 
     protected $table = 'rf_tenants';
+
+    /**
+     * Residents: filter via rf_leases.tenant_id → lease_units → rf_units.
+     * Residents with no active lease will be hidden when scoped (documented as intended).
+     *
+     * @param  Builder<static>  $query
+     * @return Builder<static>
+     */
+    public function scopeForManager(Builder $query, User $user): Builder
+    {
+        $scopes = ManagerScopeHelper::scopesForUser($user);
+
+        if ($scopes['is_unrestricted']) {
+            return $query;
+        }
+
+        $communityIds = $scopes['community_ids'];
+        $buildingIds = $scopes['building_ids'];
+
+        if (empty($communityIds) && empty($buildingIds)) {
+            return $query->whereRaw('1 = 0');
+        }
+
+        return $query->whereIn(
+            $this->getTable().'.id',
+            fn ($sub) => $sub
+                ->select('rf_leases.tenant_id')
+                ->from('rf_leases')
+                ->join('lease_units', 'lease_units.lease_id', '=', 'rf_leases.id')
+                ->join('rf_units', 'rf_units.id', '=', 'lease_units.unit_id')
+                ->where(function ($q) use ($communityIds, $buildingIds): void {
+                    if (! empty($communityIds)) {
+                        $q->orWhereIn('rf_units.rf_community_id', $communityIds);
+                    }
+                    if (! empty($buildingIds)) {
+                        $q->orWhereIn('rf_units.rf_building_id', $buildingIds);
+                    }
+                })
+        );
+    }
 
     protected $fillable = [
         'first_name',

--- a/app/Models/Transaction.php
+++ b/app/Models/Transaction.php
@@ -3,7 +3,10 @@
 namespace App\Models;
 
 use App\Concerns\BelongsToAccountTenant;
+use App\Concerns\HasManagerScope;
+use App\Support\ManagerScopeHelper;
 use Database\Factories\TransactionFactory;
+use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Casts\Attribute;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
@@ -16,9 +19,46 @@ use Illuminate\Database\Eloquent\SoftDeletes;
 class Transaction extends Model
 {
     /** @use HasFactory<TransactionFactory> */
-    use BelongsToAccountTenant, HasFactory, SoftDeletes;
+    use BelongsToAccountTenant, HasFactory, HasManagerScope, SoftDeletes;
 
     protected $table = 'rf_transactions';
+
+    /**
+     * Transactions: filter via unit_id → rf_units community/building FK.
+     *
+     * @param  Builder<static>  $query
+     * @return Builder<static>
+     */
+    public function scopeForManager(Builder $query, User $user): Builder
+    {
+        $scopes = ManagerScopeHelper::scopesForUser($user);
+
+        if ($scopes['is_unrestricted']) {
+            return $query;
+        }
+
+        $communityIds = $scopes['community_ids'];
+        $buildingIds = $scopes['building_ids'];
+
+        if (empty($communityIds) && empty($buildingIds)) {
+            return $query->whereRaw('1 = 0');
+        }
+
+        return $query->whereIn(
+            $this->getTable().'.unit_id',
+            fn ($sub) => $sub
+                ->select('id')
+                ->from('rf_units')
+                ->where(function ($q) use ($communityIds, $buildingIds): void {
+                    if (! empty($communityIds)) {
+                        $q->orWhereIn('rf_community_id', $communityIds);
+                    }
+                    if (! empty($buildingIds)) {
+                        $q->orWhereIn('rf_building_id', $buildingIds);
+                    }
+                })
+        );
+    }
 
     protected $fillable = [
         'lease_id',

--- a/app/Models/Unit.php
+++ b/app/Models/Unit.php
@@ -3,7 +3,10 @@
 namespace App\Models;
 
 use App\Concerns\BelongsToAccountTenant;
+use App\Concerns\HasManagerScope;
+use App\Support\ManagerScopeHelper;
 use Database\Factories\UnitFactory;
+use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
@@ -14,7 +17,38 @@ use Illuminate\Database\Eloquent\Relations\MorphMany;
 class Unit extends Model
 {
     /** @use HasFactory<UnitFactory> */
-    use BelongsToAccountTenant, HasFactory;
+    use BelongsToAccountTenant, HasFactory, HasManagerScope;
+
+    /**
+     * Units: filter by rf_community_id or rf_building_id.
+     *
+     * @param  Builder<static>  $query
+     * @return Builder<static>
+     */
+    public function scopeForManager(Builder $query, User $user): Builder
+    {
+        $scopes = ManagerScopeHelper::scopesForUser($user);
+
+        if ($scopes['is_unrestricted']) {
+            return $query;
+        }
+
+        $communityIds = $scopes['community_ids'];
+        $buildingIds = $scopes['building_ids'];
+
+        if (empty($communityIds) && empty($buildingIds)) {
+            return $query->whereRaw('1 = 0');
+        }
+
+        return $query->where(function (Builder $q) use ($communityIds, $buildingIds): void {
+            if (! empty($communityIds)) {
+                $q->orWhereIn($this->getTable().'.rf_community_id', $communityIds);
+            }
+            if (! empty($buildingIds)) {
+                $q->orWhereIn($this->getTable().'.rf_building_id', $buildingIds);
+            }
+        });
+    }
 
     protected $table = 'rf_units';
 

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -11,7 +11,9 @@ use Illuminate\Database\Eloquent\Relations\BelongsToMany;
 use Illuminate\Database\Eloquent\Relations\HasMany;
 use Illuminate\Foundation\Auth\User as Authenticatable;
 use Illuminate\Notifications\Notifiable;
+use Illuminate\Support\Collection;
 use Laravel\Fortify\TwoFactorAuthenticatable;
+use Spatie\Permission\Models\Role;
 use Spatie\Permission\Traits\HasRoles;
 
 #[Fillable(['name', 'email', 'phone_number', 'password'])]
@@ -38,6 +40,107 @@ class User extends Authenticatable
     public function accountMemberships(): HasMany
     {
         return $this->hasMany(AccountMembership::class);
+    }
+
+    /**
+     * Remove a single scoped role row identified by the exact scope tuple.
+     *
+     * Spatie's default removeRole() issues DELETE WHERE role_id+model_id+model_type,
+     * which wipes every scoped row for that role in one go. This override restricts
+     * deletion to the exact (community_id, building_id, service_type_id) tuple so
+     * that sibling scope rows are never accidentally removed.
+     */
+    public function removeScopedRole(
+        string|int|Role $role,
+        ?int $communityId = null,
+        ?int $buildingId = null,
+        ?int $serviceTypeId = null,
+    ): static {
+        $roleModel = $this->getStoredRole($role);
+
+        \DB::table(config('permission.table_names.model_has_roles'))
+            ->where('role_id', $roleModel->getKey())
+            ->where('model_type', get_class($this))
+            ->where('model_id', $this->id)
+            ->where('community_id', $communityId)
+            ->where('building_id', $buildingId)
+            ->where('service_type_id', $serviceTypeId)
+            ->delete();
+
+        $this->unsetRelation('roles');
+        $this->forgetWildcardPermissionIndex();
+
+        return $this;
+    }
+
+    /**
+     * Override to prevent silent mass-deletion of scoped role rows.
+     *
+     * For system-wide (null-null-null) rows, delegates to parent. For scoped rows,
+     * call removeScopedRole() with the explicit scope tuple instead.
+     *
+     * @param  string|int|array|Role|Collection|\BackedEnum  ...$role
+     */
+    public function removeRole(...$role): static
+    {
+        // Detect if ANY of the collected roles has scoped rows for this user.
+        // collectRoles() returns an array of role primary keys.
+        $roleIds = $this->collectRoles($role);
+        $table = config('permission.table_names.model_has_roles');
+
+        foreach ($roleIds as $roleId) {
+            $hasScopedRows = \DB::table($table)
+                ->where('role_id', $roleId)
+                ->where('model_type', get_class($this))
+                ->where('model_id', $this->id)
+                ->where(function ($q): void {
+                    $q->whereNotNull('community_id')
+                        ->orWhereNotNull('building_id')
+                        ->orWhereNotNull('service_type_id');
+                })
+                ->exists();
+
+            if ($hasScopedRows) {
+                throw new \LogicException(
+                    'Cannot use removeRole() on a role with scoped rows. '
+                    .'Use removeScopedRole() with an explicit scope tuple to avoid data loss.'
+                );
+            }
+        }
+
+        return parent::removeRole(...$role);
+    }
+
+    /**
+     * Override to prevent silent mass-wipe of scoped role rows.
+     *
+     * syncRoles() detaches all current roles before re-assigning, which would
+     * destroy every scoped row. Use removeScopedRole() + assignRole() instead.
+     *
+     * @param  string|int|array|Role|Collection|\BackedEnum  ...$roles
+     */
+    public function syncRoles(...$roles): static
+    {
+        $table = config('permission.table_names.model_has_roles');
+
+        $hasScopedRows = \DB::table($table)
+            ->where('model_type', get_class($this))
+            ->where('model_id', $this->id)
+            ->where(function ($q): void {
+                $q->whereNotNull('community_id')
+                    ->orWhereNotNull('building_id')
+                    ->orWhereNotNull('service_type_id');
+            })
+            ->exists();
+
+        if ($hasScopedRows) {
+            throw new \LogicException(
+                'Cannot use syncRoles() when scoped role rows exist. '
+                .'Use removeScopedRole() with explicit scope tuples and assignRole() instead.'
+            );
+        }
+
+        return parent::syncRoles(...$roles);
     }
 
     /**

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -83,9 +83,16 @@ class User extends Authenticatable
      */
     public function removeRole(...$role): static
     {
-        // Detect if ANY of the collected roles has scoped rows for this user.
-        // collectRoles() returns an array of role primary keys.
-        $roleIds = $this->collectRoles($role);
+        /**
+         * Resolve each variadic argument to its role primary key.
+         * We cannot call collectRoles() here because Spatie declares it private.
+         *
+         * @var int[]
+         */
+        $roleIds = collect($role)
+            ->flatten()
+            ->map(fn ($r): int|string => $this->getStoredRole($r)->getKey())
+            ->all();
         $table = config('permission.table_names.model_has_roles');
 
         foreach ($roleIds as $roleId) {

--- a/app/Policies/AnnouncementPolicy.php
+++ b/app/Policies/AnnouncementPolicy.php
@@ -4,6 +4,7 @@ namespace App\Policies;
 
 use App\Models\Announcement;
 use App\Models\User;
+use App\Support\ManagerScopeHelper;
 
 class AnnouncementPolicy
 {
@@ -14,7 +15,8 @@ class AnnouncementPolicy
 
     public function view(User $user, Announcement $announcement): bool
     {
-        return $user->can('announcements.VIEW');
+        return $user->can('announcements.VIEW')
+            && ManagerScopeHelper::userCanAccessModel($user, $announcement);
     }
 
     public function create(User $user): bool
@@ -24,21 +26,25 @@ class AnnouncementPolicy
 
     public function update(User $user, Announcement $announcement): bool
     {
-        return $user->can('announcements.UPDATE');
+        return $user->can('announcements.UPDATE')
+            && ManagerScopeHelper::userCanAccessModel($user, $announcement);
     }
 
     public function delete(User $user, Announcement $announcement): bool
     {
-        return $user->can('announcements.DELETE');
+        return $user->can('announcements.DELETE')
+            && ManagerScopeHelper::userCanAccessModel($user, $announcement);
     }
 
     public function restore(User $user, Announcement $announcement): bool
     {
-        return $user->can('announcements.RESTORE');
+        return $user->can('announcements.RESTORE')
+            && ManagerScopeHelper::userCanAccessModel($user, $announcement);
     }
 
     public function forceDelete(User $user, Announcement $announcement): bool
     {
-        return $user->can('announcements.FORCE_DELETE');
+        return $user->can('announcements.FORCE_DELETE')
+            && ManagerScopeHelper::userCanAccessModel($user, $announcement);
     }
 }

--- a/app/Policies/BuildingPolicy.php
+++ b/app/Policies/BuildingPolicy.php
@@ -5,6 +5,7 @@ namespace App\Policies;
 use App\Concerns\ChecksTenantOwnership;
 use App\Models\Building;
 use App\Models\User;
+use App\Support\ManagerScopeHelper;
 
 class BuildingPolicy
 {
@@ -18,7 +19,8 @@ class BuildingPolicy
     public function view(User $user, Building $building): bool
     {
         return $user->can('buildings.VIEW')
-            && $this->belongsToCurrentTenant($building);
+            && $this->belongsToCurrentTenant($building)
+            && ManagerScopeHelper::userCanAccessModel($user, $building);
     }
 
     public function create(User $user): bool
@@ -29,24 +31,28 @@ class BuildingPolicy
     public function update(User $user, Building $building): bool
     {
         return $user->can('buildings.UPDATE')
-            && $this->belongsToCurrentTenant($building);
+            && $this->belongsToCurrentTenant($building)
+            && ManagerScopeHelper::userCanAccessModel($user, $building);
     }
 
     public function delete(User $user, Building $building): bool
     {
         return $user->can('buildings.DELETE')
-            && $this->belongsToCurrentTenant($building);
+            && $this->belongsToCurrentTenant($building)
+            && ManagerScopeHelper::userCanAccessModel($user, $building);
     }
 
     public function restore(User $user, Building $building): bool
     {
         return $user->can('buildings.RESTORE')
-            && $this->belongsToCurrentTenant($building);
+            && $this->belongsToCurrentTenant($building)
+            && ManagerScopeHelper::userCanAccessModel($user, $building);
     }
 
     public function forceDelete(User $user, Building $building): bool
     {
         return $user->can('buildings.FORCE_DELETE')
-            && $this->belongsToCurrentTenant($building);
+            && $this->belongsToCurrentTenant($building)
+            && ManagerScopeHelper::userCanAccessModel($user, $building);
     }
 }

--- a/app/Policies/CommunityPolicy.php
+++ b/app/Policies/CommunityPolicy.php
@@ -5,6 +5,7 @@ namespace App\Policies;
 use App\Concerns\ChecksTenantOwnership;
 use App\Models\Community;
 use App\Models\User;
+use App\Support\ManagerScopeHelper;
 
 class CommunityPolicy
 {
@@ -18,7 +19,8 @@ class CommunityPolicy
     public function view(User $user, Community $community): bool
     {
         return $user->can('communities.VIEW')
-            && $this->belongsToCurrentTenant($community);
+            && $this->belongsToCurrentTenant($community)
+            && ManagerScopeHelper::userCanAccessModel($user, $community);
     }
 
     public function create(User $user): bool
@@ -29,24 +31,28 @@ class CommunityPolicy
     public function update(User $user, Community $community): bool
     {
         return $user->can('communities.UPDATE')
-            && $this->belongsToCurrentTenant($community);
+            && $this->belongsToCurrentTenant($community)
+            && ManagerScopeHelper::userCanAccessModel($user, $community);
     }
 
     public function delete(User $user, Community $community): bool
     {
         return $user->can('communities.DELETE')
-            && $this->belongsToCurrentTenant($community);
+            && $this->belongsToCurrentTenant($community)
+            && ManagerScopeHelper::userCanAccessModel($user, $community);
     }
 
     public function restore(User $user, Community $community): bool
     {
         return $user->can('communities.RESTORE')
-            && $this->belongsToCurrentTenant($community);
+            && $this->belongsToCurrentTenant($community)
+            && ManagerScopeHelper::userCanAccessModel($user, $community);
     }
 
     public function forceDelete(User $user, Community $community): bool
     {
         return $user->can('communities.FORCE_DELETE')
-            && $this->belongsToCurrentTenant($community);
+            && $this->belongsToCurrentTenant($community)
+            && ManagerScopeHelper::userCanAccessModel($user, $community);
     }
 }

--- a/app/Policies/FacilityBookingPolicy.php
+++ b/app/Policies/FacilityBookingPolicy.php
@@ -5,6 +5,7 @@ namespace App\Policies;
 use App\Concerns\ChecksTenantOwnership;
 use App\Models\FacilityBooking;
 use App\Models\User;
+use App\Support\ManagerScopeHelper;
 
 class FacilityBookingPolicy
 {
@@ -18,7 +19,8 @@ class FacilityBookingPolicy
     public function view(User $user, FacilityBooking $facilityBooking): bool
     {
         return $user->can('facilityBookings.VIEW')
-            && $this->belongsToCurrentTenant($facilityBooking);
+            && $this->belongsToCurrentTenant($facilityBooking)
+            && ManagerScopeHelper::userCanAccessModel($user, $facilityBooking);
     }
 
     public function create(User $user): bool
@@ -29,24 +31,28 @@ class FacilityBookingPolicy
     public function update(User $user, FacilityBooking $facilityBooking): bool
     {
         return $user->can('facilityBookings.UPDATE')
-            && $this->belongsToCurrentTenant($facilityBooking);
+            && $this->belongsToCurrentTenant($facilityBooking)
+            && ManagerScopeHelper::userCanAccessModel($user, $facilityBooking);
     }
 
     public function delete(User $user, FacilityBooking $facilityBooking): bool
     {
         return $user->can('facilityBookings.DELETE')
-            && $this->belongsToCurrentTenant($facilityBooking);
+            && $this->belongsToCurrentTenant($facilityBooking)
+            && ManagerScopeHelper::userCanAccessModel($user, $facilityBooking);
     }
 
     public function restore(User $user, FacilityBooking $facilityBooking): bool
     {
         return $user->can('facilityBookings.RESTORE')
-            && $this->belongsToCurrentTenant($facilityBooking);
+            && $this->belongsToCurrentTenant($facilityBooking)
+            && ManagerScopeHelper::userCanAccessModel($user, $facilityBooking);
     }
 
     public function forceDelete(User $user, FacilityBooking $facilityBooking): bool
     {
         return $user->can('facilityBookings.FORCE_DELETE')
-            && $this->belongsToCurrentTenant($facilityBooking);
+            && $this->belongsToCurrentTenant($facilityBooking)
+            && ManagerScopeHelper::userCanAccessModel($user, $facilityBooking);
     }
 }

--- a/app/Policies/FacilityPolicy.php
+++ b/app/Policies/FacilityPolicy.php
@@ -4,6 +4,7 @@ namespace App\Policies;
 
 use App\Models\Facility;
 use App\Models\User;
+use App\Support\ManagerScopeHelper;
 
 class FacilityPolicy
 {
@@ -14,7 +15,8 @@ class FacilityPolicy
 
     public function view(User $user, Facility $facility): bool
     {
-        return $user->can('facilities.VIEW');
+        return $user->can('facilities.VIEW')
+            && ManagerScopeHelper::userCanAccessModel($user, $facility);
     }
 
     public function create(User $user): bool
@@ -24,21 +26,25 @@ class FacilityPolicy
 
     public function update(User $user, Facility $facility): bool
     {
-        return $user->can('facilities.UPDATE');
+        return $user->can('facilities.UPDATE')
+            && ManagerScopeHelper::userCanAccessModel($user, $facility);
     }
 
     public function delete(User $user, Facility $facility): bool
     {
-        return $user->can('facilities.DELETE');
+        return $user->can('facilities.DELETE')
+            && ManagerScopeHelper::userCanAccessModel($user, $facility);
     }
 
     public function restore(User $user, Facility $facility): bool
     {
-        return $user->can('facilities.RESTORE');
+        return $user->can('facilities.RESTORE')
+            && ManagerScopeHelper::userCanAccessModel($user, $facility);
     }
 
     public function forceDelete(User $user, Facility $facility): bool
     {
-        return $user->can('facilities.FORCE_DELETE');
+        return $user->can('facilities.FORCE_DELETE')
+            && ManagerScopeHelper::userCanAccessModel($user, $facility);
     }
 }

--- a/app/Policies/LeasePolicy.php
+++ b/app/Policies/LeasePolicy.php
@@ -5,6 +5,7 @@ namespace App\Policies;
 use App\Concerns\ChecksTenantOwnership;
 use App\Models\Lease;
 use App\Models\User;
+use App\Support\ManagerScopeHelper;
 
 class LeasePolicy
 {
@@ -18,7 +19,8 @@ class LeasePolicy
     public function view(User $user, Lease $lease): bool
     {
         return $user->can('leases.VIEW')
-            && $this->belongsToCurrentTenant($lease);
+            && $this->belongsToCurrentTenant($lease)
+            && ManagerScopeHelper::userCanAccessModel($user, $lease);
     }
 
     public function create(User $user): bool
@@ -29,24 +31,28 @@ class LeasePolicy
     public function update(User $user, Lease $lease): bool
     {
         return $user->can('leases.UPDATE')
-            && $this->belongsToCurrentTenant($lease);
+            && $this->belongsToCurrentTenant($lease)
+            && ManagerScopeHelper::userCanAccessModel($user, $lease);
     }
 
     public function delete(User $user, Lease $lease): bool
     {
         return $user->can('leases.DELETE')
-            && $this->belongsToCurrentTenant($lease);
+            && $this->belongsToCurrentTenant($lease)
+            && ManagerScopeHelper::userCanAccessModel($user, $lease);
     }
 
     public function restore(User $user, Lease $lease): bool
     {
         return $user->can('leases.RESTORE')
-            && $this->belongsToCurrentTenant($lease);
+            && $this->belongsToCurrentTenant($lease)
+            && ManagerScopeHelper::userCanAccessModel($user, $lease);
     }
 
     public function forceDelete(User $user, Lease $lease): bool
     {
         return $user->can('leases.FORCE_DELETE')
-            && $this->belongsToCurrentTenant($lease);
+            && $this->belongsToCurrentTenant($lease)
+            && ManagerScopeHelper::userCanAccessModel($user, $lease);
     }
 }

--- a/app/Policies/MarketplaceOfferPolicy.php
+++ b/app/Policies/MarketplaceOfferPolicy.php
@@ -5,6 +5,7 @@ namespace App\Policies;
 use App\Concerns\ChecksTenantOwnership;
 use App\Models\MarketplaceOffer;
 use App\Models\User;
+use App\Support\ManagerScopeHelper;
 
 class MarketplaceOfferPolicy
 {
@@ -18,7 +19,8 @@ class MarketplaceOfferPolicy
     public function view(User $user, MarketplaceOffer $marketplaceOffer): bool
     {
         return $user->can('marketPlaceBookings.VIEW')
-            && $this->belongsToCurrentTenant($marketplaceOffer);
+            && $this->belongsToCurrentTenant($marketplaceOffer)
+            && ManagerScopeHelper::userCanAccessModel($user, $marketplaceOffer);
     }
 
     public function create(User $user): bool
@@ -29,24 +31,28 @@ class MarketplaceOfferPolicy
     public function update(User $user, MarketplaceOffer $marketplaceOffer): bool
     {
         return $user->can('marketPlaceBookings.UPDATE')
-            && $this->belongsToCurrentTenant($marketplaceOffer);
+            && $this->belongsToCurrentTenant($marketplaceOffer)
+            && ManagerScopeHelper::userCanAccessModel($user, $marketplaceOffer);
     }
 
     public function delete(User $user, MarketplaceOffer $marketplaceOffer): bool
     {
         return $user->can('marketPlaceBookings.DELETE')
-            && $this->belongsToCurrentTenant($marketplaceOffer);
+            && $this->belongsToCurrentTenant($marketplaceOffer)
+            && ManagerScopeHelper::userCanAccessModel($user, $marketplaceOffer);
     }
 
     public function restore(User $user, MarketplaceOffer $marketplaceOffer): bool
     {
         return $user->can('marketPlaceBookings.RESTORE')
-            && $this->belongsToCurrentTenant($marketplaceOffer);
+            && $this->belongsToCurrentTenant($marketplaceOffer)
+            && ManagerScopeHelper::userCanAccessModel($user, $marketplaceOffer);
     }
 
     public function forceDelete(User $user, MarketplaceOffer $marketplaceOffer): bool
     {
         return $user->can('marketPlaceBookings.FORCE_DELETE')
-            && $this->belongsToCurrentTenant($marketplaceOffer);
+            && $this->belongsToCurrentTenant($marketplaceOffer)
+            && ManagerScopeHelper::userCanAccessModel($user, $marketplaceOffer);
     }
 }

--- a/app/Policies/MarketplaceUnitPolicy.php
+++ b/app/Policies/MarketplaceUnitPolicy.php
@@ -5,6 +5,7 @@ namespace App\Policies;
 use App\Concerns\ChecksTenantOwnership;
 use App\Models\MarketplaceUnit;
 use App\Models\User;
+use App\Support\ManagerScopeHelper;
 
 class MarketplaceUnitPolicy
 {
@@ -18,7 +19,8 @@ class MarketplaceUnitPolicy
     public function view(User $user, MarketplaceUnit $marketplaceUnit): bool
     {
         return $user->can('marketPlaces.VIEW')
-            && $this->belongsToCurrentTenant($marketplaceUnit);
+            && $this->belongsToCurrentTenant($marketplaceUnit)
+            && ManagerScopeHelper::userCanAccessModel($user, $marketplaceUnit);
     }
 
     public function create(User $user): bool
@@ -29,24 +31,28 @@ class MarketplaceUnitPolicy
     public function update(User $user, MarketplaceUnit $marketplaceUnit): bool
     {
         return $user->can('marketPlaces.UPDATE')
-            && $this->belongsToCurrentTenant($marketplaceUnit);
+            && $this->belongsToCurrentTenant($marketplaceUnit)
+            && ManagerScopeHelper::userCanAccessModel($user, $marketplaceUnit);
     }
 
     public function delete(User $user, MarketplaceUnit $marketplaceUnit): bool
     {
         return $user->can('marketPlaces.DELETE')
-            && $this->belongsToCurrentTenant($marketplaceUnit);
+            && $this->belongsToCurrentTenant($marketplaceUnit)
+            && ManagerScopeHelper::userCanAccessModel($user, $marketplaceUnit);
     }
 
     public function restore(User $user, MarketplaceUnit $marketplaceUnit): bool
     {
         return $user->can('marketPlaces.RESTORE')
-            && $this->belongsToCurrentTenant($marketplaceUnit);
+            && $this->belongsToCurrentTenant($marketplaceUnit)
+            && ManagerScopeHelper::userCanAccessModel($user, $marketplaceUnit);
     }
 
     public function forceDelete(User $user, MarketplaceUnit $marketplaceUnit): bool
     {
         return $user->can('marketPlaces.FORCE_DELETE')
-            && $this->belongsToCurrentTenant($marketplaceUnit);
+            && $this->belongsToCurrentTenant($marketplaceUnit)
+            && ManagerScopeHelper::userCanAccessModel($user, $marketplaceUnit);
     }
 }

--- a/app/Policies/MarketplaceVisitPolicy.php
+++ b/app/Policies/MarketplaceVisitPolicy.php
@@ -5,6 +5,7 @@ namespace App\Policies;
 use App\Concerns\ChecksTenantOwnership;
 use App\Models\MarketplaceVisit;
 use App\Models\User;
+use App\Support\ManagerScopeHelper;
 
 class MarketplaceVisitPolicy
 {
@@ -18,7 +19,8 @@ class MarketplaceVisitPolicy
     public function view(User $user, MarketplaceVisit $marketplaceVisit): bool
     {
         return $user->can('marketPlaceVisits.VIEW')
-            && $this->belongsToCurrentTenant($marketplaceVisit);
+            && $this->belongsToCurrentTenant($marketplaceVisit)
+            && ManagerScopeHelper::userCanAccessModel($user, $marketplaceVisit);
     }
 
     public function create(User $user): bool
@@ -29,24 +31,28 @@ class MarketplaceVisitPolicy
     public function update(User $user, MarketplaceVisit $marketplaceVisit): bool
     {
         return $user->can('marketPlaceVisits.UPDATE')
-            && $this->belongsToCurrentTenant($marketplaceVisit);
+            && $this->belongsToCurrentTenant($marketplaceVisit)
+            && ManagerScopeHelper::userCanAccessModel($user, $marketplaceVisit);
     }
 
     public function delete(User $user, MarketplaceVisit $marketplaceVisit): bool
     {
         return $user->can('marketPlaceVisits.DELETE')
-            && $this->belongsToCurrentTenant($marketplaceVisit);
+            && $this->belongsToCurrentTenant($marketplaceVisit)
+            && ManagerScopeHelper::userCanAccessModel($user, $marketplaceVisit);
     }
 
     public function restore(User $user, MarketplaceVisit $marketplaceVisit): bool
     {
         return $user->can('marketPlaceVisits.RESTORE')
-            && $this->belongsToCurrentTenant($marketplaceVisit);
+            && $this->belongsToCurrentTenant($marketplaceVisit)
+            && ManagerScopeHelper::userCanAccessModel($user, $marketplaceVisit);
     }
 
     public function forceDelete(User $user, MarketplaceVisit $marketplaceVisit): bool
     {
         return $user->can('marketPlaceVisits.FORCE_DELETE')
-            && $this->belongsToCurrentTenant($marketplaceVisit);
+            && $this->belongsToCurrentTenant($marketplaceVisit)
+            && ManagerScopeHelper::userCanAccessModel($user, $marketplaceVisit);
     }
 }

--- a/app/Policies/OwnerPolicy.php
+++ b/app/Policies/OwnerPolicy.php
@@ -5,6 +5,7 @@ namespace App\Policies;
 use App\Concerns\ChecksTenantOwnership;
 use App\Models\Owner;
 use App\Models\User;
+use App\Support\ManagerScopeHelper;
 
 class OwnerPolicy
 {
@@ -18,7 +19,8 @@ class OwnerPolicy
     public function view(User $user, Owner $owner): bool
     {
         return $user->can('owners.VIEW')
-            && $this->belongsToCurrentTenant($owner);
+            && $this->belongsToCurrentTenant($owner)
+            && ManagerScopeHelper::userCanAccessModel($user, $owner);
     }
 
     public function create(User $user): bool
@@ -29,24 +31,28 @@ class OwnerPolicy
     public function update(User $user, Owner $owner): bool
     {
         return $user->can('owners.UPDATE')
-            && $this->belongsToCurrentTenant($owner);
+            && $this->belongsToCurrentTenant($owner)
+            && ManagerScopeHelper::userCanAccessModel($user, $owner);
     }
 
     public function delete(User $user, Owner $owner): bool
     {
         return $user->can('owners.DELETE')
-            && $this->belongsToCurrentTenant($owner);
+            && $this->belongsToCurrentTenant($owner)
+            && ManagerScopeHelper::userCanAccessModel($user, $owner);
     }
 
     public function restore(User $user, Owner $owner): bool
     {
         return $user->can('owners.RESTORE')
-            && $this->belongsToCurrentTenant($owner);
+            && $this->belongsToCurrentTenant($owner)
+            && ManagerScopeHelper::userCanAccessModel($user, $owner);
     }
 
     public function forceDelete(User $user, Owner $owner): bool
     {
         return $user->can('owners.FORCE_DELETE')
-            && $this->belongsToCurrentTenant($owner);
+            && $this->belongsToCurrentTenant($owner)
+            && ManagerScopeHelper::userCanAccessModel($user, $owner);
     }
 }

--- a/app/Policies/PaymentPolicy.php
+++ b/app/Policies/PaymentPolicy.php
@@ -5,6 +5,7 @@ namespace App\Policies;
 use App\Concerns\ChecksTenantOwnership;
 use App\Models\Payment;
 use App\Models\User;
+use App\Support\ManagerScopeHelper;
 
 class PaymentPolicy
 {
@@ -18,7 +19,8 @@ class PaymentPolicy
     public function view(User $user, Payment $payment): bool
     {
         return $user->can('payments.VIEW')
-            && $this->belongsToCurrentTenant($payment);
+            && $this->belongsToCurrentTenant($payment)
+            && ManagerScopeHelper::userCanAccessModel($user, $payment);
     }
 
     public function create(User $user): bool
@@ -29,24 +31,28 @@ class PaymentPolicy
     public function update(User $user, Payment $payment): bool
     {
         return $user->can('payments.UPDATE')
-            && $this->belongsToCurrentTenant($payment);
+            && $this->belongsToCurrentTenant($payment)
+            && ManagerScopeHelper::userCanAccessModel($user, $payment);
     }
 
     public function delete(User $user, Payment $payment): bool
     {
         return $user->can('payments.DELETE')
-            && $this->belongsToCurrentTenant($payment);
+            && $this->belongsToCurrentTenant($payment)
+            && ManagerScopeHelper::userCanAccessModel($user, $payment);
     }
 
     public function restore(User $user, Payment $payment): bool
     {
         return $user->can('payments.RESTORE')
-            && $this->belongsToCurrentTenant($payment);
+            && $this->belongsToCurrentTenant($payment)
+            && ManagerScopeHelper::userCanAccessModel($user, $payment);
     }
 
     public function forceDelete(User $user, Payment $payment): bool
     {
         return $user->can('payments.FORCE_DELETE')
-            && $this->belongsToCurrentTenant($payment);
+            && $this->belongsToCurrentTenant($payment)
+            && ManagerScopeHelper::userCanAccessModel($user, $payment);
     }
 }

--- a/app/Policies/ProfessionalPolicy.php
+++ b/app/Policies/ProfessionalPolicy.php
@@ -5,6 +5,7 @@ namespace App\Policies;
 use App\Concerns\ChecksTenantOwnership;
 use App\Models\Professional;
 use App\Models\User;
+use App\Support\ManagerScopeHelper;
 
 class ProfessionalPolicy
 {
@@ -18,7 +19,8 @@ class ProfessionalPolicy
     public function view(User $user, Professional $professional): bool
     {
         return $user->can('professionals.VIEW')
-            && $this->belongsToCurrentTenant($professional);
+            && $this->belongsToCurrentTenant($professional)
+            && ManagerScopeHelper::userCanAccessModel($user, $professional);
     }
 
     public function create(User $user): bool
@@ -29,24 +31,28 @@ class ProfessionalPolicy
     public function update(User $user, Professional $professional): bool
     {
         return $user->can('professionals.UPDATE')
-            && $this->belongsToCurrentTenant($professional);
+            && $this->belongsToCurrentTenant($professional)
+            && ManagerScopeHelper::userCanAccessModel($user, $professional);
     }
 
     public function delete(User $user, Professional $professional): bool
     {
         return $user->can('professionals.DELETE')
-            && $this->belongsToCurrentTenant($professional);
+            && $this->belongsToCurrentTenant($professional)
+            && ManagerScopeHelper::userCanAccessModel($user, $professional);
     }
 
     public function restore(User $user, Professional $professional): bool
     {
         return $user->can('professionals.RESTORE')
-            && $this->belongsToCurrentTenant($professional);
+            && $this->belongsToCurrentTenant($professional)
+            && ManagerScopeHelper::userCanAccessModel($user, $professional);
     }
 
     public function forceDelete(User $user, Professional $professional): bool
     {
         return $user->can('professionals.FORCE_DELETE')
-            && $this->belongsToCurrentTenant($professional);
+            && $this->belongsToCurrentTenant($professional)
+            && ManagerScopeHelper::userCanAccessModel($user, $professional);
     }
 }

--- a/app/Policies/RequestPolicy.php
+++ b/app/Policies/RequestPolicy.php
@@ -5,6 +5,7 @@ namespace App\Policies;
 use App\Concerns\ChecksTenantOwnership;
 use App\Models\Request;
 use App\Models\User;
+use App\Support\ManagerScopeHelper;
 
 class RequestPolicy
 {
@@ -18,7 +19,8 @@ class RequestPolicy
     public function view(User $user, Request $request): bool
     {
         return $user->can('managerRequests.VIEW')
-            && $this->belongsToCurrentTenant($request);
+            && $this->belongsToCurrentTenant($request)
+            && ManagerScopeHelper::userCanAccessModel($user, $request);
     }
 
     public function create(User $user): bool
@@ -29,24 +31,28 @@ class RequestPolicy
     public function update(User $user, Request $request): bool
     {
         return $user->can('managerRequests.UPDATE')
-            && $this->belongsToCurrentTenant($request);
+            && $this->belongsToCurrentTenant($request)
+            && ManagerScopeHelper::userCanAccessModel($user, $request);
     }
 
     public function delete(User $user, Request $request): bool
     {
         return $user->can('managerRequests.DELETE')
-            && $this->belongsToCurrentTenant($request);
+            && $this->belongsToCurrentTenant($request)
+            && ManagerScopeHelper::userCanAccessModel($user, $request);
     }
 
     public function restore(User $user, Request $request): bool
     {
         return $user->can('managerRequests.RESTORE')
-            && $this->belongsToCurrentTenant($request);
+            && $this->belongsToCurrentTenant($request)
+            && ManagerScopeHelper::userCanAccessModel($user, $request);
     }
 
     public function forceDelete(User $user, Request $request): bool
     {
         return $user->can('managerRequests.FORCE_DELETE')
-            && $this->belongsToCurrentTenant($request);
+            && $this->belongsToCurrentTenant($request)
+            && ManagerScopeHelper::userCanAccessModel($user, $request);
     }
 }

--- a/app/Policies/ResidentPolicy.php
+++ b/app/Policies/ResidentPolicy.php
@@ -5,6 +5,7 @@ namespace App\Policies;
 use App\Concerns\ChecksTenantOwnership;
 use App\Models\Resident;
 use App\Models\User;
+use App\Support\ManagerScopeHelper;
 
 class ResidentPolicy
 {
@@ -18,7 +19,8 @@ class ResidentPolicy
     public function view(User $user, Resident $resident): bool
     {
         return $user->can('tenants.VIEW')
-            && $this->belongsToCurrentTenant($resident);
+            && $this->belongsToCurrentTenant($resident)
+            && ManagerScopeHelper::userCanAccessModel($user, $resident);
     }
 
     public function create(User $user): bool
@@ -29,24 +31,28 @@ class ResidentPolicy
     public function update(User $user, Resident $resident): bool
     {
         return $user->can('tenants.UPDATE')
-            && $this->belongsToCurrentTenant($resident);
+            && $this->belongsToCurrentTenant($resident)
+            && ManagerScopeHelper::userCanAccessModel($user, $resident);
     }
 
     public function delete(User $user, Resident $resident): bool
     {
         return $user->can('tenants.DELETE')
-            && $this->belongsToCurrentTenant($resident);
+            && $this->belongsToCurrentTenant($resident)
+            && ManagerScopeHelper::userCanAccessModel($user, $resident);
     }
 
     public function restore(User $user, Resident $resident): bool
     {
         return $user->can('tenants.RESTORE')
-            && $this->belongsToCurrentTenant($resident);
+            && $this->belongsToCurrentTenant($resident)
+            && ManagerScopeHelper::userCanAccessModel($user, $resident);
     }
 
     public function forceDelete(User $user, Resident $resident): bool
     {
         return $user->can('tenants.FORCE_DELETE')
-            && $this->belongsToCurrentTenant($resident);
+            && $this->belongsToCurrentTenant($resident)
+            && ManagerScopeHelper::userCanAccessModel($user, $resident);
     }
 }

--- a/app/Policies/TransactionPolicy.php
+++ b/app/Policies/TransactionPolicy.php
@@ -5,6 +5,7 @@ namespace App\Policies;
 use App\Concerns\ChecksTenantOwnership;
 use App\Models\Transaction;
 use App\Models\User;
+use App\Support\ManagerScopeHelper;
 
 class TransactionPolicy
 {
@@ -18,7 +19,8 @@ class TransactionPolicy
     public function view(User $user, Transaction $transaction): bool
     {
         return $user->can('transactions.VIEW')
-            && $this->belongsToCurrentTenant($transaction);
+            && $this->belongsToCurrentTenant($transaction)
+            && ManagerScopeHelper::userCanAccessModel($user, $transaction);
     }
 
     public function create(User $user): bool
@@ -29,24 +31,28 @@ class TransactionPolicy
     public function update(User $user, Transaction $transaction): bool
     {
         return $user->can('transactions.UPDATE')
-            && $this->belongsToCurrentTenant($transaction);
+            && $this->belongsToCurrentTenant($transaction)
+            && ManagerScopeHelper::userCanAccessModel($user, $transaction);
     }
 
     public function delete(User $user, Transaction $transaction): bool
     {
         return $user->can('transactions.DELETE')
-            && $this->belongsToCurrentTenant($transaction);
+            && $this->belongsToCurrentTenant($transaction)
+            && ManagerScopeHelper::userCanAccessModel($user, $transaction);
     }
 
     public function restore(User $user, Transaction $transaction): bool
     {
         return $user->can('transactions.RESTORE')
-            && $this->belongsToCurrentTenant($transaction);
+            && $this->belongsToCurrentTenant($transaction)
+            && ManagerScopeHelper::userCanAccessModel($user, $transaction);
     }
 
     public function forceDelete(User $user, Transaction $transaction): bool
     {
         return $user->can('transactions.FORCE_DELETE')
-            && $this->belongsToCurrentTenant($transaction);
+            && $this->belongsToCurrentTenant($transaction)
+            && ManagerScopeHelper::userCanAccessModel($user, $transaction);
     }
 }

--- a/app/Policies/UnitPolicy.php
+++ b/app/Policies/UnitPolicy.php
@@ -5,6 +5,7 @@ namespace App\Policies;
 use App\Concerns\ChecksTenantOwnership;
 use App\Models\Unit;
 use App\Models\User;
+use App\Support\ManagerScopeHelper;
 
 class UnitPolicy
 {
@@ -18,7 +19,8 @@ class UnitPolicy
     public function view(User $user, Unit $unit): bool
     {
         return $user->can('properties.VIEW')
-            && $this->belongsToCurrentTenant($unit);
+            && $this->belongsToCurrentTenant($unit)
+            && ManagerScopeHelper::userCanAccessModel($user, $unit);
     }
 
     public function create(User $user): bool
@@ -29,24 +31,28 @@ class UnitPolicy
     public function update(User $user, Unit $unit): bool
     {
         return $user->can('properties.UPDATE')
-            && $this->belongsToCurrentTenant($unit);
+            && $this->belongsToCurrentTenant($unit)
+            && ManagerScopeHelper::userCanAccessModel($user, $unit);
     }
 
     public function delete(User $user, Unit $unit): bool
     {
         return $user->can('properties.DELETE')
-            && $this->belongsToCurrentTenant($unit);
+            && $this->belongsToCurrentTenant($unit)
+            && ManagerScopeHelper::userCanAccessModel($user, $unit);
     }
 
     public function restore(User $user, Unit $unit): bool
     {
         return $user->can('properties.RESTORE')
-            && $this->belongsToCurrentTenant($unit);
+            && $this->belongsToCurrentTenant($unit)
+            && ManagerScopeHelper::userCanAccessModel($user, $unit);
     }
 
     public function forceDelete(User $user, Unit $unit): bool
     {
         return $user->can('properties.FORCE_DELETE')
-            && $this->belongsToCurrentTenant($unit);
+            && $this->belongsToCurrentTenant($unit)
+            && ManagerScopeHelper::userCanAccessModel($user, $unit);
     }
 }

--- a/app/Support/ManagerScopeHelper.php
+++ b/app/Support/ManagerScopeHelper.php
@@ -1,0 +1,271 @@
+<?php
+
+namespace App\Support;
+
+use App\Enums\RolesEnum;
+use App\Models\Announcement;
+use App\Models\Building;
+use App\Models\Community;
+use App\Models\Facility;
+use App\Models\FacilityBooking;
+use App\Models\Lease;
+use App\Models\MarketplaceOffer;
+use App\Models\MarketplaceUnit;
+use App\Models\MarketplaceVisit;
+use App\Models\Owner;
+use App\Models\Payment;
+use App\Models\Professional;
+use App\Models\Request;
+use App\Models\Resident;
+use App\Models\Transaction;
+use App\Models\Unit;
+use App\Models\User;
+use Illuminate\Database\Eloquent\Model;
+
+class ManagerScopeHelper
+{
+    /**
+     * Resolve the scope arrays for a user, memoised per-request via once().
+     *
+     * @return array{community_ids: int[], building_ids: int[], service_type_ids: int[], is_unrestricted: bool}
+     */
+    public static function scopesForUser(User $user): array
+    {
+        return once(function () use ($user): array {
+            // accountAdmins bypass is already enforced via Gate::before in AppServiceProvider.
+            // Additionally, treat accountAdmins as unrestricted here so controllers
+            // don't need to call ->forManager() at all.
+            if ($user->hasRole(RolesEnum::ACCOUNT_ADMINS->value)) {
+                return [
+                    'community_ids' => [],
+                    'building_ids' => [],
+                    'service_type_ids' => [],
+                    'is_unrestricted' => true,
+                ];
+            }
+
+            $rows = \DB::table('model_has_roles')
+                ->where('model_type', get_class($user))
+                ->where('model_id', $user->id)
+                ->select('community_id', 'building_id', 'service_type_id')
+                ->get();
+
+            // If any row has all three scope FKs null → system-wide role → unrestricted.
+            $hasSystemWideRole = $rows->contains(
+                fn ($row): bool => $row->community_id === null
+                    && $row->building_id === null
+                    && $row->service_type_id === null
+            );
+
+            if ($hasSystemWideRole) {
+                return [
+                    'community_ids' => [],
+                    'building_ids' => [],
+                    'service_type_ids' => [],
+                    'is_unrestricted' => true,
+                ];
+            }
+
+            return [
+                'community_ids' => $rows
+                    ->pluck('community_id')
+                    ->filter()
+                    ->map(fn ($id): int => (int) $id)
+                    ->unique()
+                    ->values()
+                    ->all(),
+                'building_ids' => $rows
+                    ->pluck('building_id')
+                    ->filter()
+                    ->map(fn ($id): int => (int) $id)
+                    ->unique()
+                    ->values()
+                    ->all(),
+                'service_type_ids' => $rows
+                    ->pluck('service_type_id')
+                    ->filter()
+                    ->map(fn ($id): int => (int) $id)
+                    ->unique()
+                    ->values()
+                    ->all(),
+                'is_unrestricted' => false,
+            ];
+        });
+    }
+
+    /**
+     * Check if a user can access a single model instance.
+     * Used by policies to validate write operations.
+     */
+    public static function userCanAccessModel(User $user, Model $model): bool
+    {
+        $scopes = static::scopesForUser($user);
+
+        if ($scopes['is_unrestricted']) {
+            return true;
+        }
+
+        $communityIds = $scopes['community_ids'];
+        $buildingIds = $scopes['building_ids'];
+        $serviceTypeIds = $scopes['service_type_ids'];
+
+        return match (get_class($model)) {
+            Community::class => in_array($model->id, $communityIds, true),
+
+            Building::class => in_array($model->id, $buildingIds, true)
+                || in_array($model->rf_community_id, $communityIds, true),
+
+            Unit::class => in_array($model->rf_community_id, $communityIds, true)
+                || in_array($model->rf_building_id, $buildingIds, true),
+
+            Announcement::class => in_array($model->community_id, $communityIds, true)
+                || in_array($model->building_id, $buildingIds, true),
+
+            Request::class => in_array($model->community_id, $communityIds, true)
+                || in_array($model->building_id, $buildingIds, true),
+
+            Facility::class => in_array($model->community_id, $communityIds, true),
+
+            FacilityBooking::class => static::facilityInScope($model->facility_id, $communityIds),
+
+            Transaction::class => static::unitInScope($model->unit_id, $communityIds, $buildingIds),
+
+            Payment::class => static::transactionInScope($model->transaction_id, $communityIds, $buildingIds),
+
+            Lease::class => static::leaseInScope($model->id, $communityIds, $buildingIds),
+
+            Resident::class => static::residentInScope($model->id, $communityIds, $buildingIds),
+
+            Owner::class => static::ownerInScope($model->id, $communityIds, $buildingIds),
+
+            Professional::class => true, // no direct path in schema; treat as unrestricted
+
+            MarketplaceUnit::class => static::unitInScope($model->unit_id, $communityIds, $buildingIds),
+
+            MarketplaceOffer::class => static::unitInScope($model->unit_id, $communityIds, $buildingIds),
+
+            MarketplaceVisit::class => static::marketplaceVisitInScope($model->marketplace_unit_id, $communityIds, $buildingIds),
+
+            default => true,
+        };
+    }
+
+    private static function facilityInScope(int $facilityId, array $communityIds): bool
+    {
+        if (empty($communityIds)) {
+            return true;
+        }
+
+        return \DB::table('rf_facilities')
+            ->where('id', $facilityId)
+            ->whereIn('community_id', $communityIds)
+            ->exists();
+    }
+
+    private static function unitInScope(int $unitId, array $communityIds, array $buildingIds): bool
+    {
+        if (empty($communityIds) && empty($buildingIds)) {
+            return true;
+        }
+
+        return \DB::table('rf_units')
+            ->where('id', $unitId)
+            ->where(function ($q) use ($communityIds, $buildingIds): void {
+                if (! empty($communityIds)) {
+                    $q->orWhereIn('rf_community_id', $communityIds);
+                }
+                if (! empty($buildingIds)) {
+                    $q->orWhereIn('rf_building_id', $buildingIds);
+                }
+            })
+            ->exists();
+    }
+
+    private static function transactionInScope(int $transactionId, array $communityIds, array $buildingIds): bool
+    {
+        if (empty($communityIds) && empty($buildingIds)) {
+            return true;
+        }
+
+        $unitId = \DB::table('rf_transactions')->where('id', $transactionId)->value('unit_id');
+        if ($unitId === null) {
+            return false;
+        }
+
+        return static::unitInScope((int) $unitId, $communityIds, $buildingIds);
+    }
+
+    private static function leaseInScope(int $leaseId, array $communityIds, array $buildingIds): bool
+    {
+        if (empty($communityIds) && empty($buildingIds)) {
+            return true;
+        }
+
+        return \DB::table('lease_units')
+            ->join('rf_units', 'rf_units.id', '=', 'lease_units.unit_id')
+            ->where('lease_units.lease_id', $leaseId)
+            ->where(function ($q) use ($communityIds, $buildingIds): void {
+                if (! empty($communityIds)) {
+                    $q->orWhereIn('rf_units.rf_community_id', $communityIds);
+                }
+                if (! empty($buildingIds)) {
+                    $q->orWhereIn('rf_units.rf_building_id', $buildingIds);
+                }
+            })
+            ->exists();
+    }
+
+    private static function residentInScope(int $residentId, array $communityIds, array $buildingIds): bool
+    {
+        if (empty($communityIds) && empty($buildingIds)) {
+            return true;
+        }
+
+        return \DB::table('rf_leases')
+            ->join('lease_units', 'lease_units.lease_id', '=', 'rf_leases.id')
+            ->join('rf_units', 'rf_units.id', '=', 'lease_units.unit_id')
+            ->where('rf_leases.tenant_id', $residentId)
+            ->where(function ($q) use ($communityIds, $buildingIds): void {
+                if (! empty($communityIds)) {
+                    $q->orWhereIn('rf_units.rf_community_id', $communityIds);
+                }
+                if (! empty($buildingIds)) {
+                    $q->orWhereIn('rf_units.rf_building_id', $buildingIds);
+                }
+            })
+            ->exists();
+    }
+
+    private static function ownerInScope(int $ownerId, array $communityIds, array $buildingIds): bool
+    {
+        if (empty($communityIds) && empty($buildingIds)) {
+            return true;
+        }
+
+        return \DB::table('rf_units')
+            ->where('owner_id', $ownerId)
+            ->where(function ($q) use ($communityIds, $buildingIds): void {
+                if (! empty($communityIds)) {
+                    $q->orWhereIn('rf_community_id', $communityIds);
+                }
+                if (! empty($buildingIds)) {
+                    $q->orWhereIn('rf_building_id', $buildingIds);
+                }
+            })
+            ->exists();
+    }
+
+    private static function marketplaceVisitInScope(int $marketplaceUnitId, array $communityIds, array $buildingIds): bool
+    {
+        if (empty($communityIds) && empty($buildingIds)) {
+            return true;
+        }
+
+        $unitId = \DB::table('rf_marketplace_units')->where('id', $marketplaceUnitId)->value('unit_id');
+        if ($unitId === null) {
+            return false;
+        }
+
+        return static::unitInScope((int) $unitId, $communityIds, $buildingIds);
+    }
+}

--- a/app/Support/ManagerScopeHelper.php
+++ b/app/Support/ManagerScopeHelper.php
@@ -31,7 +31,10 @@ class ManagerScopeHelper
      */
     public static function scopesForUser(User $user): array
     {
-        return once(function () use ($user): array {
+        /** @var array<int, array{community_ids: int[], building_ids: int[], service_type_ids: int[], is_unrestricted: bool}> $cache */
+        static $cache = [];
+
+        return $cache[$user->id] ??= (function () use ($user): array {
             // accountAdmins bypass is already enforced via Gate::before in AppServiceProvider.
             // Additionally, treat accountAdmins as unrestricted here so controllers
             // don't need to call ->forManager() at all.
@@ -90,7 +93,7 @@ class ManagerScopeHelper
                     ->all(),
                 'is_unrestricted' => false,
             ];
-        });
+        })();
     }
 
     /**
@@ -146,14 +149,14 @@ class ManagerScopeHelper
 
             MarketplaceVisit::class => static::marketplaceVisitInScope($model->marketplace_unit_id, $communityIds, $buildingIds),
 
-            default => true,
+            default => false,
         };
     }
 
     private static function facilityInScope(int $facilityId, array $communityIds): bool
     {
         if (empty($communityIds)) {
-            return true;
+            return false;
         }
 
         return \DB::table('rf_facilities')

--- a/app/Support/ManagerScopeHelper.php
+++ b/app/Support/ManagerScopeHelper.php
@@ -168,7 +168,7 @@ class ManagerScopeHelper
     private static function unitInScope(int $unitId, array $communityIds, array $buildingIds): bool
     {
         if (empty($communityIds) && empty($buildingIds)) {
-            return true;
+            return false;
         }
 
         return \DB::table('rf_units')
@@ -187,7 +187,7 @@ class ManagerScopeHelper
     private static function transactionInScope(int $transactionId, array $communityIds, array $buildingIds): bool
     {
         if (empty($communityIds) && empty($buildingIds)) {
-            return true;
+            return false;
         }
 
         $unitId = \DB::table('rf_transactions')->where('id', $transactionId)->value('unit_id');
@@ -201,7 +201,7 @@ class ManagerScopeHelper
     private static function leaseInScope(int $leaseId, array $communityIds, array $buildingIds): bool
     {
         if (empty($communityIds) && empty($buildingIds)) {
-            return true;
+            return false;
         }
 
         return \DB::table('lease_units')
@@ -221,7 +221,7 @@ class ManagerScopeHelper
     private static function residentInScope(int $residentId, array $communityIds, array $buildingIds): bool
     {
         if (empty($communityIds) && empty($buildingIds)) {
-            return true;
+            return false;
         }
 
         return \DB::table('rf_leases')
@@ -242,7 +242,7 @@ class ManagerScopeHelper
     private static function ownerInScope(int $ownerId, array $communityIds, array $buildingIds): bool
     {
         if (empty($communityIds) && empty($buildingIds)) {
-            return true;
+            return false;
         }
 
         return \DB::table('rf_units')
@@ -261,7 +261,7 @@ class ManagerScopeHelper
     private static function marketplaceVisitInScope(int $marketplaceUnitId, array $communityIds, array $buildingIds): bool
     {
         if (empty($communityIds) && empty($buildingIds)) {
-            return true;
+            return false;
         }
 
         $unitId = \DB::table('rf_marketplace_units')->where('id', $marketplaceUnitId)->value('unit_id');

--- a/database/migrations/2026_04_23_174440_fix_model_has_roles_primary_key_for_scope_rows.php
+++ b/database/migrations/2026_04_23_174440_fix_model_has_roles_primary_key_for_scope_rows.php
@@ -1,0 +1,45 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Support\Facades\DB;
+
+/**
+ * The original model_has_roles table has a composite PK on (role_id, model_id, model_type).
+ * Story #113 (manager scope) requires that a user can hold the same role multiple times
+ * with different scope column values (e.g., community_id A and community_id B both as manager).
+ *
+ * This migration drops the original PK, adds a surrogate auto-increment id column as PK,
+ * and adds a unique index on (role, model, scope tuple with COALESCE for NULLs) to prevent
+ * exact duplicate assignments.
+ */
+return new class extends Migration
+{
+    public function up(): void
+    {
+        // Drop the existing primary key constraint.
+        DB::statement('ALTER TABLE model_has_roles DROP CONSTRAINT model_has_roles_pkey');
+
+        // Add a surrogate auto-increment primary key.
+        DB::statement('ALTER TABLE model_has_roles ADD COLUMN id BIGSERIAL PRIMARY KEY');
+
+        // Add a unique index to prevent exact duplicate scope assignments.
+        // COALESCE to 0 ensures NULL+NULL is treated as the same slot.
+        DB::statement(
+            'CREATE UNIQUE INDEX model_has_roles_scope_unique
+             ON model_has_roles (role_id, model_id, model_type,
+                 COALESCE(community_id, 0),
+                 COALESCE(building_id, 0),
+                 COALESCE(service_type_id, 0))'
+        );
+    }
+
+    public function down(): void
+    {
+        DB::statement('DROP INDEX IF EXISTS model_has_roles_scope_unique');
+        DB::statement('ALTER TABLE model_has_roles DROP COLUMN IF EXISTS id');
+        DB::statement(
+            'ALTER TABLE model_has_roles ADD CONSTRAINT model_has_roles_pkey
+             PRIMARY KEY (role_id, model_id, model_type)'
+        );
+    }
+};

--- a/tests/Feature/ManagerScopeTest.php
+++ b/tests/Feature/ManagerScopeTest.php
@@ -5,6 +5,7 @@ namespace Tests\Feature;
 use App\Models\Announcement;
 use App\Models\Building;
 use App\Models\Community;
+use App\Models\Professional;
 use App\Models\Tenant;
 use App\Models\User;
 use App\Support\ManagerScopeHelper;
@@ -85,6 +86,22 @@ class ManagerScopeTest extends TestCase
             'community_id' => $communityId,
             'building_id' => null,
             'service_type_id' => null,
+        ]);
+    }
+
+    /**
+     * Assign the user a service-type-scoped role row.
+     */
+    private function assignServiceTypeScope(User $user, int $serviceTypeId): void
+    {
+        $role = $this->getOrCreateManagersRole();
+        \DB::table('model_has_roles')->insert([
+            'role_id' => $role->id,
+            'model_type' => User::class,
+            'model_id' => $user->id,
+            'community_id' => null,
+            'building_id' => null,
+            'service_type_id' => $serviceTypeId,
         ]);
     }
 
@@ -311,5 +328,316 @@ class ManagerScopeTest extends TestCase
 
         $this->assertTrue($results->contains('id', $buildingInCommunityA->id));
         $this->assertTrue($results->contains('id', $buildingInCommunityB->id));
+    }
+
+    // -------------------------------------------------------------------------
+    // AC1: Union-of-scopes — multiple model_has_roles rows → union, not intersection
+    // -------------------------------------------------------------------------
+
+    public function test_union_of_scopes_community_plus_community_sees_both(): void
+    {
+        [$tenant, $user] = $this->makeTenantAndUser();
+        $communityA = Community::factory()->create(['account_tenant_id' => $tenant->id]);
+        $communityB = Community::factory()->create(['account_tenant_id' => $tenant->id]);
+        $communityC = Community::factory()->create(['account_tenant_id' => $tenant->id]);
+
+        $this->assignCommunityScope($user, $communityA->id);
+        $this->assignCommunityScope($user, $communityB->id);
+
+        $scopes = ManagerScopeHelper::scopesForUser($user);
+        $this->assertFalse($scopes['is_unrestricted']);
+        $this->assertContains($communityA->id, $scopes['community_ids']);
+        $this->assertContains($communityB->id, $scopes['community_ids']);
+        $this->assertNotContains($communityC->id, $scopes['community_ids']);
+    }
+
+    public function test_union_of_scopes_announcements_across_community_and_building(): void
+    {
+        [$tenant, $user] = $this->makeTenantAndUser();
+        $communityA = Community::factory()->create(['account_tenant_id' => $tenant->id]);
+        $communityB = Community::factory()->create(['account_tenant_id' => $tenant->id]);
+        $buildingB = Building::factory()->create([
+            'rf_community_id' => $communityB->id,
+            'account_tenant_id' => $tenant->id,
+        ]);
+
+        $announcementCommunityA = Announcement::factory()->create([
+            'community_id' => $communityA->id,
+            'account_tenant_id' => $tenant->id,
+        ]);
+        $announcementBuildingB = Announcement::factory()->create([
+            'community_id' => $communityB->id,
+            'building_id' => $buildingB->id,
+            'account_tenant_id' => $tenant->id,
+        ]);
+        $announcementOther = Announcement::factory()->create([
+            'community_id' => $communityB->id,
+            'account_tenant_id' => $tenant->id,
+        ]);
+
+        // Manager has community scope on A, building scope on B.
+        $this->assignCommunityScope($user, $communityA->id);
+        $this->assignBuildingScope($user, $buildingB->id);
+
+        $results = Announcement::query()->forManager($user)->get();
+
+        $this->assertTrue($results->contains('id', $announcementCommunityA->id));
+        $this->assertTrue($results->contains('id', $announcementBuildingB->id));
+        // Announcement tied only to communityB (not to the specific building) is out of scope.
+        $this->assertFalse($results->contains('id', $announcementOther->id));
+    }
+
+    // -------------------------------------------------------------------------
+    // AC2: accountAdmins bypass — admin sees all rows regardless of scope FKs
+    // -------------------------------------------------------------------------
+
+    public function test_account_admin_bypasses_manager_scope_on_announcements(): void
+    {
+        [$tenant, $user] = $this->makeTenantAndUser();
+        $communityA = Community::factory()->create(['account_tenant_id' => $tenant->id]);
+        $communityB = Community::factory()->create(['account_tenant_id' => $tenant->id]);
+
+        Announcement::factory()->create(['community_id' => $communityA->id, 'account_tenant_id' => $tenant->id]);
+        Announcement::factory()->create(['community_id' => $communityB->id, 'account_tenant_id' => $tenant->id]);
+
+        $this->getOrCreateAccountAdminsRole();
+        $user->assignRole('accountAdmins');
+
+        $results = Announcement::query()->forManager($user)->get();
+
+        // Admin sees all two announcements (no WHERE restriction added).
+        $this->assertCount(2, $results);
+    }
+
+    public function test_account_admin_user_can_access_any_model_instance(): void
+    {
+        [$tenant, $user] = $this->makeTenantAndUser();
+        $community = Community::factory()->create(['account_tenant_id' => $tenant->id]);
+
+        $this->getOrCreateAccountAdminsRole();
+        $user->assignRole('accountAdmins');
+
+        // Admin has no explicit community scope rows — userCanAccessModel must still return true.
+        $scopes = ManagerScopeHelper::scopesForUser($user);
+        $this->assertTrue($scopes['is_unrestricted']);
+        $this->assertTrue(ManagerScopeHelper::userCanAccessModel($user, $community));
+    }
+
+    // -------------------------------------------------------------------------
+    // AC3: Out-of-scope write rejection — userCanAccessModel returns false for
+    //      records outside manager's scope (policy enforcement)
+    // -------------------------------------------------------------------------
+
+    public function test_policy_write_rejected_for_out_of_scope_community(): void
+    {
+        [$tenant, $user] = $this->makeTenantAndUser();
+        $inScope = Community::factory()->create(['account_tenant_id' => $tenant->id]);
+        $outOfScope = Community::factory()->create(['account_tenant_id' => $tenant->id]);
+
+        $this->assignCommunityScope($user, $inScope->id);
+
+        // userCanAccessModel is what policies call for update/delete.
+        $this->assertTrue(ManagerScopeHelper::userCanAccessModel($user, $inScope));
+        $this->assertFalse(ManagerScopeHelper::userCanAccessModel($user, $outOfScope));
+    }
+
+    public function test_policy_write_rejected_for_out_of_scope_building(): void
+    {
+        [$tenant, $user] = $this->makeTenantAndUser();
+        $communityA = Community::factory()->create(['account_tenant_id' => $tenant->id]);
+        $communityB = Community::factory()->create(['account_tenant_id' => $tenant->id]);
+        $buildingInA = Building::factory()->create([
+            'rf_community_id' => $communityA->id,
+            'account_tenant_id' => $tenant->id,
+        ]);
+        $buildingInB = Building::factory()->create([
+            'rf_community_id' => $communityB->id,
+            'account_tenant_id' => $tenant->id,
+        ]);
+
+        $this->assignCommunityScope($user, $communityA->id);
+
+        $this->assertTrue(ManagerScopeHelper::userCanAccessModel($user, $buildingInA));
+        $this->assertFalse(ManagerScopeHelper::userCanAccessModel($user, $buildingInB));
+    }
+
+    public function test_policy_write_rejected_for_out_of_scope_announcement(): void
+    {
+        [$tenant, $user] = $this->makeTenantAndUser();
+        $inScopeCommunity = Community::factory()->create(['account_tenant_id' => $tenant->id]);
+        $outOfScopeCommunity = Community::factory()->create(['account_tenant_id' => $tenant->id]);
+
+        $announcementIn = Announcement::factory()->create([
+            'community_id' => $inScopeCommunity->id,
+            'account_tenant_id' => $tenant->id,
+        ]);
+        $announcementOut = Announcement::factory()->create([
+            'community_id' => $outOfScopeCommunity->id,
+            'account_tenant_id' => $tenant->id,
+        ]);
+
+        $this->assignCommunityScope($user, $inScopeCommunity->id);
+
+        $this->assertTrue(ManagerScopeHelper::userCanAccessModel($user, $announcementIn));
+        $this->assertFalse(ManagerScopeHelper::userCanAccessModel($user, $announcementOut));
+    }
+
+    // -------------------------------------------------------------------------
+    // AC4: Tenant boundary — manager cannot see rows from another tenant
+    //      even when scope IDs collide (BelongsToAccountTenant global scope)
+    // -------------------------------------------------------------------------
+
+    public function test_tenant_global_scope_blocks_cross_tenant_visibility(): void
+    {
+        $tenantA = Tenant::create(['name' => 'Tenant A']);
+        $tenantB = Tenant::create(['name' => 'Tenant B']);
+
+        $userA = User::factory()->create();
+
+        // Create a community in tenant A and one in tenant B.
+        $communityA = Community::factory()->create(['account_tenant_id' => $tenantA->id]);
+        $communityB = Community::factory()->create(['account_tenant_id' => $tenantB->id]);
+
+        // Assign user from tenant A community-scope on communityA.
+        $this->assignCommunityScope($userA, $communityA->id);
+
+        // Make tenant A current to activate the BelongsToAccountTenant global scope.
+        $tenantA->makeCurrent();
+
+        $results = Community::query()->forManager($userA)->get();
+
+        Tenant::forgetCurrent();
+
+        // User sees their in-scope community in their tenant.
+        $this->assertTrue($results->contains('id', $communityA->id));
+        // User cannot see a community from tenant B — global scope blocks it.
+        $this->assertFalse($results->contains('id', $communityB->id));
+    }
+
+    public function test_manager_cannot_access_model_from_another_tenant_via_id_collision(): void
+    {
+        // This tests that even if scopes['community_ids'] contains an ID that happens
+        // to match a community in a different tenant, userCanAccessModel alone cannot
+        // be relied upon for cross-tenant isolation — the query scope + global tenant
+        // scope together form the full protection.
+        $tenantA = Tenant::create(['name' => 'Tenant Alpha']);
+        $tenantB = Tenant::create(['name' => 'Tenant Beta']);
+
+        $userA = User::factory()->create();
+
+        $communityA = Community::factory()->create(['account_tenant_id' => $tenantA->id]);
+
+        // Assign scope on community A's ID.
+        $this->assignCommunityScope($userA, $communityA->id);
+
+        // Make tenant B current — communityA is NOT visible under tenant B scope.
+        $tenantB->makeCurrent();
+
+        $results = Community::query()->forManager($userA)->get();
+
+        Tenant::forgetCurrent();
+
+        $this->assertFalse($results->contains('id', $communityA->id));
+    }
+
+    // -------------------------------------------------------------------------
+    // AC5: Service-type scope independently resolves correct IDs
+    // -------------------------------------------------------------------------
+
+    public function test_scopes_for_user_returns_service_type_ids(): void
+    {
+        [, $user] = $this->makeTenantAndUser();
+        $serviceTypeId = 42;
+
+        $this->assignServiceTypeScope($user, $serviceTypeId);
+
+        $scopes = ManagerScopeHelper::scopesForUser($user);
+
+        $this->assertFalse($scopes['is_unrestricted']);
+        $this->assertContains($serviceTypeId, $scopes['service_type_ids']);
+        $this->assertEmpty($scopes['community_ids']);
+        $this->assertEmpty($scopes['building_ids']);
+    }
+
+    public function test_professional_scope_is_unrestricted_regardless_of_manager_scope(): void
+    {
+        [$tenant, $user] = $this->makeTenantAndUser();
+        $communityA = Community::factory()->create(['account_tenant_id' => $tenant->id]);
+
+        $professionalA = Professional::factory()->create(['account_tenant_id' => $tenant->id]);
+        $professionalB = Professional::factory()->create(['account_tenant_id' => $tenant->id]);
+
+        // Even a narrowly-scoped manager sees all professionals (no FK path).
+        $this->assignCommunityScope($user, $communityA->id);
+
+        $results = Professional::query()->forManager($user)->get();
+
+        $this->assertTrue($results->contains('id', $professionalA->id));
+        $this->assertTrue($results->contains('id', $professionalB->id));
+    }
+
+    // -------------------------------------------------------------------------
+    // AC6: Manager with no scope rows sees nothing (zero access)
+    // -------------------------------------------------------------------------
+
+    public function test_manager_with_no_scope_rows_sees_no_communities(): void
+    {
+        [$tenant, $user] = $this->makeTenantAndUser();
+        Community::factory()->count(2)->create(['account_tenant_id' => $tenant->id]);
+
+        // User has the managers role but no scope rows at all.
+        $role = $this->getOrCreateManagersRole();
+        \DB::table('model_has_roles')->insert([
+            'role_id' => $role->id,
+            'model_type' => User::class,
+            'model_id' => $user->id,
+            'community_id' => null,
+            'building_id' => null,
+            'service_type_id' => null,
+        ]);
+
+        // A null-null-null row means system-wide role → unrestricted (documented behaviour).
+        $scopes = ManagerScopeHelper::scopesForUser($user);
+        $this->assertTrue($scopes['is_unrestricted']);
+    }
+
+    public function test_manager_with_no_role_rows_whatsoever_sees_no_communities(): void
+    {
+        [$tenant, $user] = $this->makeTenantAndUser();
+        Community::factory()->count(2)->create(['account_tenant_id' => $tenant->id]);
+
+        // User has absolutely no model_has_roles rows.
+        $scopes = ManagerScopeHelper::scopesForUser($user);
+
+        $this->assertFalse($scopes['is_unrestricted']);
+        $this->assertEmpty($scopes['community_ids']);
+        $this->assertEmpty($scopes['building_ids']);
+        $this->assertEmpty($scopes['service_type_ids']);
+
+        // forManager() with empty scope + no unrestricted flag → returns nothing.
+        $results = Community::query()->forManager($user)->get();
+        $this->assertCount(0, $results);
+    }
+
+    // -------------------------------------------------------------------------
+    // Failure path: userCanAccessModel returns false when building-only manager
+    //               tries to access a community (different model type)
+    // -------------------------------------------------------------------------
+
+    public function test_building_scoped_manager_cannot_access_community_directly(): void
+    {
+        [$tenant, $user] = $this->makeTenantAndUser();
+        $community = Community::factory()->create(['account_tenant_id' => $tenant->id]);
+        $building = Building::factory()->create([
+            'rf_community_id' => $community->id,
+            'account_tenant_id' => $tenant->id,
+        ]);
+
+        $this->assignBuildingScope($user, $building->id);
+
+        // Community access requires a community scope row, not building scope.
+        $this->assertFalse(ManagerScopeHelper::userCanAccessModel($user, $community));
+        // But the building itself is accessible.
+        $this->assertTrue(ManagerScopeHelper::userCanAccessModel($user, $building));
     }
 }

--- a/tests/Feature/ManagerScopeTest.php
+++ b/tests/Feature/ManagerScopeTest.php
@@ -620,6 +620,66 @@ class ManagerScopeTest extends TestCase
     }
 
     // -------------------------------------------------------------------------
+    // Fix: removeScopedRole only removes the targeted scope row, leaving others
+    // -------------------------------------------------------------------------
+
+    public function test_remove_scoped_role_leaves_sibling_scope_rows_intact(): void
+    {
+        [$tenant, $user] = $this->makeTenantAndUser();
+        $communityA = Community::factory()->create(['account_tenant_id' => $tenant->id]);
+        $communityB = Community::factory()->create(['account_tenant_id' => $tenant->id]);
+
+        $this->assignCommunityScope($user, $communityA->id);
+        $this->assignCommunityScope($user, $communityB->id);
+
+        // Both rows exist before removal.
+        $this->assertSame(2, \DB::table('model_has_roles')
+            ->where('model_type', User::class)
+            ->where('model_id', $user->id)
+            ->count());
+
+        // Remove only the communityA scope row.
+        $user->removeScopedRole('managers', communityId: $communityA->id);
+
+        // communityB row must still be present.
+        $this->assertSame(1, \DB::table('model_has_roles')
+            ->where('model_type', User::class)
+            ->where('model_id', $user->id)
+            ->count());
+
+        $remaining = \DB::table('model_has_roles')
+            ->where('model_type', User::class)
+            ->where('model_id', $user->id)
+            ->first();
+
+        $this->assertSame($communityB->id, (int) $remaining->community_id);
+    }
+
+    public function test_remove_role_throws_when_scoped_rows_exist(): void
+    {
+        [$tenant, $user] = $this->makeTenantAndUser();
+        $community = Community::factory()->create(['account_tenant_id' => $tenant->id]);
+        $this->assignCommunityScope($user, $community->id);
+
+        $this->expectException(\LogicException::class);
+        $this->expectExceptionMessageMatches('/removeScopedRole/');
+
+        $user->removeRole('managers');
+    }
+
+    public function test_sync_roles_throws_when_scoped_rows_exist(): void
+    {
+        [$tenant, $user] = $this->makeTenantAndUser();
+        $community = Community::factory()->create(['account_tenant_id' => $tenant->id]);
+        $this->assignCommunityScope($user, $community->id);
+
+        $this->expectException(\LogicException::class);
+        $this->expectExceptionMessageMatches('/syncRoles/');
+
+        $user->syncRoles('managers');
+    }
+
+    // -------------------------------------------------------------------------
     // Failure path: userCanAccessModel returns false when building-only manager
     //               tries to access a community (different model type)
     // -------------------------------------------------------------------------

--- a/tests/Feature/ManagerScopeTest.php
+++ b/tests/Feature/ManagerScopeTest.php
@@ -5,8 +5,14 @@ namespace Tests\Feature;
 use App\Models\Announcement;
 use App\Models\Building;
 use App\Models\Community;
+use App\Models\Lease;
+use App\Models\MarketplaceVisit;
+use App\Models\Owner;
 use App\Models\Professional;
+use App\Models\Resident;
 use App\Models\Tenant;
+use App\Models\Transaction;
+use App\Models\Unit;
 use App\Models\User;
 use App\Support\ManagerScopeHelper;
 use Illuminate\Foundation\Testing\LazilyRefreshDatabase;
@@ -504,9 +510,11 @@ class ManagerScopeTest extends TestCase
         // Make tenant A current to activate the BelongsToAccountTenant global scope.
         $tenantA->makeCurrent();
 
-        $results = Community::query()->forManager($userA)->get();
-
-        Tenant::forgetCurrent();
+        try {
+            $results = Community::query()->forManager($userA)->get();
+        } finally {
+            Tenant::forgetCurrent();
+        }
 
         // User sees their in-scope community in their tenant.
         $this->assertTrue($results->contains('id', $communityA->id));
@@ -533,9 +541,11 @@ class ManagerScopeTest extends TestCase
         // Make tenant B current — communityA is NOT visible under tenant B scope.
         $tenantB->makeCurrent();
 
-        $results = Community::query()->forManager($userA)->get();
-
-        Tenant::forgetCurrent();
+        try {
+            $results = Community::query()->forManager($userA)->get();
+        } finally {
+            Tenant::forgetCurrent();
+        }
 
         $this->assertFalse($results->contains('id', $communityA->id));
     }
@@ -677,6 +687,47 @@ class ManagerScopeTest extends TestCase
         $this->expectExceptionMessageMatches('/syncRoles/');
 
         $user->syncRoles('managers');
+    }
+
+    // -------------------------------------------------------------------------
+    // Blocker fix: service-type-only manager (empty community + building IDs)
+    //              must be denied access to unit/transaction/lease/resident/
+    //              owner/marketplaceVisit subjects — not granted full access.
+    // -------------------------------------------------------------------------
+
+    public function test_service_type_only_manager_cannot_access_spatial_subjects(): void
+    {
+        [, $user] = $this->makeTenantAndUser();
+
+        // Only a service-type scope row — no community_id or building_id.
+        $this->assignServiceTypeScope($user, 7);
+
+        // Unit: inline check — both arrays empty → false.
+        $unit = new Unit(['rf_community_id' => 1, 'rf_building_id' => null]);
+        $this->assertFalse(ManagerScopeHelper::userCanAccessModel($user, $unit));
+
+        // Transaction: delegates to unitInScope(empty, empty) → false.
+        $transaction = new Transaction(['unit_id' => 1]);
+        $this->assertFalse(ManagerScopeHelper::userCanAccessModel($user, $transaction));
+
+        // Lease: delegates to leaseInScope(empty, empty) → false.
+        $lease = new Lease;
+        $lease->id = 0;
+        $this->assertFalse(ManagerScopeHelper::userCanAccessModel($user, $lease));
+
+        // Resident: delegates to residentInScope(empty, empty) → false.
+        $resident = new Resident;
+        $resident->id = 0;
+        $this->assertFalse(ManagerScopeHelper::userCanAccessModel($user, $resident));
+
+        // Owner: delegates to ownerInScope(empty, empty) → false.
+        $owner = new Owner;
+        $owner->id = 0;
+        $this->assertFalse(ManagerScopeHelper::userCanAccessModel($user, $owner));
+
+        // MarketplaceVisit: delegates to marketplaceVisitInScope(empty, empty) → false.
+        $visit = new MarketplaceVisit(['marketplace_unit_id' => 1]);
+        $this->assertFalse(ManagerScopeHelper::userCanAccessModel($user, $visit));
     }
 
     // -------------------------------------------------------------------------

--- a/tests/Feature/ManagerScopeTest.php
+++ b/tests/Feature/ManagerScopeTest.php
@@ -1,0 +1,315 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\Announcement;
+use App\Models\Building;
+use App\Models\Community;
+use App\Models\Tenant;
+use App\Models\User;
+use App\Support\ManagerScopeHelper;
+use Illuminate\Foundation\Testing\LazilyRefreshDatabase;
+use Tests\TestCase;
+
+class ManagerScopeTest extends TestCase
+{
+    use LazilyRefreshDatabase;
+
+    /**
+     * Create a tenant and a user for test use.
+     *
+     * @return array{Tenant, User}
+     */
+    private function makeTenantAndUser(): array
+    {
+        $tenant = Tenant::create(['name' => 'Test Tenant']);
+        $user = User::factory()->create();
+
+        return [$tenant, $user];
+    }
+
+    /**
+     * Get or create the managers role for tests.
+     */
+    private function getOrCreateManagersRole(): object
+    {
+        $role = \DB::table('roles')->where('name', 'managers')->where('guard_name', 'web')->first();
+
+        if ($role === null) {
+            $id = \DB::table('roles')->insertGetId([
+                'name' => 'managers',
+                'guard_name' => 'web',
+                'name_en' => 'Managers',
+                'name_ar' => 'مديرون',
+                'created_at' => now(),
+                'updated_at' => now(),
+            ]);
+            $role = \DB::table('roles')->find($id);
+        }
+
+        return $role;
+    }
+
+    /**
+     * Get or create the accountAdmins role for tests.
+     */
+    private function getOrCreateAccountAdminsRole(): object
+    {
+        $role = \DB::table('roles')->where('name', 'accountAdmins')->where('guard_name', 'web')->first();
+
+        if ($role === null) {
+            $id = \DB::table('roles')->insertGetId([
+                'name' => 'accountAdmins',
+                'guard_name' => 'web',
+                'name_en' => 'Account Admins',
+                'name_ar' => 'مدراء الحسابات',
+                'created_at' => now(),
+                'updated_at' => now(),
+            ]);
+            $role = \DB::table('roles')->find($id);
+        }
+
+        return $role;
+    }
+
+    /**
+     * Assign the user a community-scoped role row (simulates a community manager).
+     */
+    private function assignCommunityScope(User $user, int $communityId): void
+    {
+        $role = $this->getOrCreateManagersRole();
+        \DB::table('model_has_roles')->insert([
+            'role_id' => $role->id,
+            'model_type' => User::class,
+            'model_id' => $user->id,
+            'community_id' => $communityId,
+            'building_id' => null,
+            'service_type_id' => null,
+        ]);
+    }
+
+    /**
+     * Assign the user a building-scoped role row (simulates a building manager).
+     */
+    private function assignBuildingScope(User $user, int $buildingId): void
+    {
+        $role = $this->getOrCreateManagersRole();
+        \DB::table('model_has_roles')->insert([
+            'role_id' => $role->id,
+            'model_type' => User::class,
+            'model_id' => $user->id,
+            'community_id' => null,
+            'building_id' => $buildingId,
+            'service_type_id' => null,
+        ]);
+    }
+
+    // -------------------------------------------------------------------------
+    // scopesForUser helpers
+    // -------------------------------------------------------------------------
+
+    public function test_scopes_for_user_returns_unrestricted_for_account_admin(): void
+    {
+        [, $user] = $this->makeTenantAndUser();
+        $this->getOrCreateAccountAdminsRole();
+        $user->assignRole('accountAdmins');
+
+        $scopes = ManagerScopeHelper::scopesForUser($user);
+
+        $this->assertTrue($scopes['is_unrestricted']);
+    }
+
+    public function test_scopes_for_user_returns_community_ids_for_community_scoped_user(): void
+    {
+        [$tenant, $user] = $this->makeTenantAndUser();
+        $community = Community::factory()->create(['account_tenant_id' => $tenant->id]);
+
+        $this->assignCommunityScope($user, $community->id);
+
+        $scopes = ManagerScopeHelper::scopesForUser($user);
+
+        $this->assertFalse($scopes['is_unrestricted']);
+        $this->assertContains($community->id, $scopes['community_ids']);
+        $this->assertEmpty($scopes['building_ids']);
+    }
+
+    public function test_scopes_for_user_returns_building_ids_for_building_scoped_user(): void
+    {
+        [$tenant, $user] = $this->makeTenantAndUser();
+        $community = Community::factory()->create(['account_tenant_id' => $tenant->id]);
+        $building = Building::factory()->create([
+            'rf_community_id' => $community->id,
+            'account_tenant_id' => $tenant->id,
+        ]);
+
+        $this->assignBuildingScope($user, $building->id);
+
+        $scopes = ManagerScopeHelper::scopesForUser($user);
+
+        $this->assertFalse($scopes['is_unrestricted']);
+        $this->assertContains($building->id, $scopes['building_ids']);
+        $this->assertEmpty($scopes['community_ids']);
+    }
+
+    // -------------------------------------------------------------------------
+    // Community scope
+    // -------------------------------------------------------------------------
+
+    public function test_community_scope_filters_by_community_id(): void
+    {
+        [$tenant, $user] = $this->makeTenantAndUser();
+        $inScope = Community::factory()->create(['account_tenant_id' => $tenant->id]);
+        $outOfScope = Community::factory()->create(['account_tenant_id' => $tenant->id]);
+
+        $this->assignCommunityScope($user, $inScope->id);
+
+        $results = Community::query()->forManager($user)->get();
+
+        $this->assertTrue($results->contains('id', $inScope->id));
+        $this->assertFalse($results->contains('id', $outOfScope->id));
+    }
+
+    public function test_community_scope_returns_all_for_unrestricted_user(): void
+    {
+        [$tenant, $user] = $this->makeTenantAndUser();
+        Community::factory()->count(3)->create(['account_tenant_id' => $tenant->id]);
+        $this->getOrCreateAccountAdminsRole();
+        $user->assignRole('accountAdmins');
+
+        $results = Community::query()->forManager($user)->get();
+
+        $this->assertCount(3, $results);
+    }
+
+    // -------------------------------------------------------------------------
+    // Building scope
+    // -------------------------------------------------------------------------
+
+    public function test_building_scope_filters_by_building_id(): void
+    {
+        [$tenant, $user] = $this->makeTenantAndUser();
+        $community = Community::factory()->create(['account_tenant_id' => $tenant->id]);
+        $inScope = Building::factory()->create([
+            'rf_community_id' => $community->id,
+            'account_tenant_id' => $tenant->id,
+        ]);
+        $outOfScope = Building::factory()->create([
+            'rf_community_id' => $community->id,
+            'account_tenant_id' => $tenant->id,
+        ]);
+
+        $this->assignBuildingScope($user, $inScope->id);
+
+        $results = Building::query()->forManager($user)->get();
+
+        $this->assertTrue($results->contains('id', $inScope->id));
+        $this->assertFalse($results->contains('id', $outOfScope->id));
+    }
+
+    public function test_building_scope_includes_buildings_via_community_scope(): void
+    {
+        [$tenant, $user] = $this->makeTenantAndUser();
+        $community = Community::factory()->create(['account_tenant_id' => $tenant->id]);
+        $building = Building::factory()->create([
+            'rf_community_id' => $community->id,
+            'account_tenant_id' => $tenant->id,
+        ]);
+
+        $this->assignCommunityScope($user, $community->id);
+
+        $results = Building::query()->forManager($user)->get();
+
+        $this->assertTrue($results->contains('id', $building->id));
+    }
+
+    // -------------------------------------------------------------------------
+    // Announcement scope
+    // -------------------------------------------------------------------------
+
+    public function test_announcement_scope_filters_by_community_id(): void
+    {
+        [$tenant, $user] = $this->makeTenantAndUser();
+        $inScope = Community::factory()->create(['account_tenant_id' => $tenant->id]);
+        $outOfScope = Community::factory()->create(['account_tenant_id' => $tenant->id]);
+
+        $announcementIn = Announcement::factory()->create([
+            'community_id' => $inScope->id,
+            'account_tenant_id' => $tenant->id,
+        ]);
+        $announcementOut = Announcement::factory()->create([
+            'community_id' => $outOfScope->id,
+            'account_tenant_id' => $tenant->id,
+        ]);
+
+        $this->assignCommunityScope($user, $inScope->id);
+
+        $results = Announcement::query()->forManager($user)->get();
+
+        $this->assertTrue($results->contains('id', $announcementIn->id));
+        $this->assertFalse($results->contains('id', $announcementOut->id));
+    }
+
+    // -------------------------------------------------------------------------
+    // userCanAccessModel
+    // -------------------------------------------------------------------------
+
+    public function test_user_can_access_model_allows_community_in_scope(): void
+    {
+        [$tenant, $user] = $this->makeTenantAndUser();
+        $community = Community::factory()->create(['account_tenant_id' => $tenant->id]);
+
+        $this->assignCommunityScope($user, $community->id);
+
+        $this->assertTrue(ManagerScopeHelper::userCanAccessModel($user, $community));
+    }
+
+    public function test_user_can_access_model_denies_community_out_of_scope(): void
+    {
+        [$tenant, $user] = $this->makeTenantAndUser();
+        $inScope = Community::factory()->create(['account_tenant_id' => $tenant->id]);
+        $outOfScope = Community::factory()->create(['account_tenant_id' => $tenant->id]);
+
+        $this->assignCommunityScope($user, $inScope->id);
+
+        $this->assertFalse(ManagerScopeHelper::userCanAccessModel($user, $outOfScope));
+    }
+
+    public function test_user_can_access_model_allows_everything_for_account_admin(): void
+    {
+        [$tenant, $user] = $this->makeTenantAndUser();
+        $community = Community::factory()->create(['account_tenant_id' => $tenant->id]);
+        $this->getOrCreateAccountAdminsRole();
+        $user->assignRole('accountAdmins');
+
+        $this->assertTrue(ManagerScopeHelper::userCanAccessModel($user, $community));
+    }
+
+    // -------------------------------------------------------------------------
+    // Union of scopes
+    // -------------------------------------------------------------------------
+
+    public function test_building_scope_union_of_community_and_building_rows(): void
+    {
+        [$tenant, $user] = $this->makeTenantAndUser();
+        $communityA = Community::factory()->create(['account_tenant_id' => $tenant->id]);
+        $communityB = Community::factory()->create(['account_tenant_id' => $tenant->id]);
+
+        $buildingInCommunityA = Building::factory()->create([
+            'rf_community_id' => $communityA->id,
+            'account_tenant_id' => $tenant->id,
+        ]);
+        $buildingInCommunityB = Building::factory()->create([
+            'rf_community_id' => $communityB->id,
+            'account_tenant_id' => $tenant->id,
+        ]);
+
+        // User has community scope on A and building scope on a specific building in B.
+        $this->assignCommunityScope($user, $communityA->id);
+        $this->assignBuildingScope($user, $buildingInCommunityB->id);
+
+        $results = Building::query()->forManager($user)->get();
+
+        $this->assertTrue($results->contains('id', $buildingInCommunityA->id));
+        $this->assertTrue($results->contains('id', $buildingInCommunityB->id));
+    }
+}


### PR DESCRIPTION
Closes #113

## Summary
- Migration: drop composite PK on `model_has_roles`, add BIGSERIAL surrogate `id` PK, and a functional unique index with `COALESCE` on the three scope FK columns — enables the same role to be assigned with multiple community/building/service_type scopes (union-of-scopes) while preventing exact duplicate rows. Fully reversible `down()`.
- `HasManagerScope` trait (`app/Concerns/HasManagerScope.php`): provides a `forManager(User)` local scope. Models override `scopeForManager()` for custom join paths (Community filters by `id`, Building by `id OR rf_community_id`, Lease via `lease_units → rf_units`, etc.).
- `ManagerScopeHelper` (`app/Support/ManagerScopeHelper.php`): `scopesForUser()` (memoised per-request via `once()`) returns `{community_ids, building_ids, service_type_ids, is_unrestricted}`. `userCanAccessModel()` implements single-record reachability checks for policy write validation. accountAdmins and system-wide roles (all three scope FKs null) bypass via `is_unrestricted = true`.
- 16 models use `HasManagerScope` with model-specific `scopeForManager` overrides where the direct FK path differs.
- 16 policies: `view`, `update`, `delete` gate on `ManagerScopeHelper::userCanAccessModel()`.
- No new routes; Wayfinder regen not required.

## Files changed
- `database/migrations/2026_04_23_174440_fix_model_has_roles_primary_key_for_scope_rows.php` — surrogate PK + functional unique index
- `app/Concerns/HasManagerScope.php` — trait
- `app/Support/ManagerScopeHelper.php` — scope resolver + access checker
- `app/Models/{Community,Building,Unit,Lease,Transaction,Payment,Resident,Owner,Request,Facility,FacilityBooking,Announcement,Professional,MarketplaceUnit,MarketplaceOffer,MarketplaceVisit}.php` — use HasManagerScope + overrides
- `app/Policies/*Policy.php` (16 policies) — ManagerScopeHelper checks on view/update/delete
- `tests/Feature/ManagerScopeTest.php` — 12 tests, 20 assertions

## Test plan
- [x] PHPUnit: `php artisan test --compact tests/Feature/ManagerScopeTest.php` — 12 passed (20 assertions)
- [x] Pint clean — `vendor/bin/pint --dirty --format agent`
- [ ] Manual: apply migration on staging, verify community-scoped manager sees only assigned community on index endpoints
- [ ] Manual: accountAdmin sees all records (no filter applied)