### PR TITLE
feat: rbac:migrate-admin-roles — migrate rf_admins.role into model_has_roles (#117)

### DIFF
--- a/app/Console/Commands/MigrateAdminRoles.php
+++ b/app/Console/Commands/MigrateAdminRoles.php
@@ -54,7 +54,6 @@ class MigrateAdminRoles extends Command
         }
 
         // 2. Resolve morph alias for Admin model once.
-        $morphAlias = Relation::getMorphedModel(Admin::class) ?? Admin::class;
         // Reverse lookup: morphMap maps alias→FQCN; we need FQCN→alias.
         $map = Relation::morphMap();
         $morphType = array_search(Admin::class, $map);

--- a/app/Console/Commands/MigrateAdminRoles.php
+++ b/app/Console/Commands/MigrateAdminRoles.php
@@ -1,0 +1,146 @@
+<?php
+
+namespace App\Console\Commands;
+
+use App\Enums\AdminRole;
+use App\Models\Admin;
+use App\Models\Role;
+use Illuminate\Console\Command;
+use Illuminate\Database\Eloquent\Relations\Relation;
+use Illuminate\Support\Collection;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Log;
+use Spatie\Permission\PermissionRegistrar;
+
+class MigrateAdminRoles extends Command
+{
+    /**
+     * The name and signature of the console command.
+     *
+     * @var string
+     */
+    protected $signature = 'rbac:migrate-admin-roles
+                            {--dry-run : Log what would be inserted without writing}';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Migrate rf_admins.role values into model_has_roles for all tenants';
+
+    /**
+     * Execute the console command.
+     */
+    public function handle(): int
+    {
+        $isDryRun = (bool) $this->option('dry-run');
+
+        // 1. Resolve all 5 AdminRole system roles up-front into a name→id map.
+        $expectedNames = array_column(AdminRole::cases(), 'value');
+
+        /** @var Collection<string, int> $roleMap */
+        $roleMap = Role::withoutGlobalScopes()
+            ->whereNull('account_tenant_id')
+            ->whereIn('name', $expectedNames)
+            ->pluck('id', 'name');
+
+        $missing = array_diff($expectedNames, $roleMap->keys()->all());
+
+        if (! empty($missing)) {
+            $this->error('The following roles are missing from the database (run RbacSeeder first): '.implode(', ', $missing));
+
+            return self::FAILURE;
+        }
+
+        // 2. Resolve morph alias for Admin model once.
+        $morphAlias = Relation::getMorphedModel(Admin::class) ?? Admin::class;
+        // Reverse lookup: morphMap maps alias→FQCN; we need FQCN→alias.
+        $map = Relation::morphMap();
+        $morphType = array_search(Admin::class, $map);
+        if ($morphType === false) {
+            $morphType = Admin::class;
+        }
+
+        $totalInserted = 0;
+        $totalSkippedExisting = 0;
+        $totalSkippedInvalid = 0;
+
+        // 3. Chunk through all admins across all tenants.
+        Admin::withoutGlobalScopes()->chunkById(200, function ($admins) use (
+            $roleMap,
+            $morphType,
+            $isDryRun,
+            &$totalInserted,
+            &$totalSkippedExisting,
+            &$totalSkippedInvalid,
+        ): void {
+            $adminIds = $admins->pluck('id')->all();
+
+            // Pre-fetch existing (model_id, role_id) pairs for this chunk.
+            $existing = DB::table('model_has_roles')
+                ->where('model_type', $morphType)
+                ->whereIn('model_id', $adminIds)
+                ->get(['model_id', 'role_id'])
+                ->mapToGroups(fn ($row) => [$row->model_id => $row->role_id])
+                ->map(fn ($ids) => $ids->all());
+
+            $toInsert = [];
+
+            foreach ($admins as $admin) {
+                // Retrieve raw role string from attributes to avoid enum cast errors.
+                $rawRole = $admin->getRawOriginal('role');
+
+                if ($rawRole === null) {
+                    Log::warning("MigrateAdminRoles: admin {$admin->id} has null role — skipped");
+                    $totalSkippedInvalid++;
+
+                    continue;
+                }
+
+                if (! $roleMap->has($rawRole)) {
+                    Log::warning("MigrateAdminRoles: admin {$admin->id} has unrecognised role '{$rawRole}' — skipped");
+                    $totalSkippedInvalid++;
+
+                    continue;
+                }
+
+                $roleId = $roleMap->get($rawRole);
+
+                $existingRoleIds = $existing->get($admin->id, []);
+                if (in_array($roleId, $existingRoleIds, strict: true)) {
+                    $totalSkippedExisting++;
+
+                    continue;
+                }
+
+                $toInsert[] = [
+                    'role_id' => $roleId,
+                    'model_type' => $morphType,
+                    'model_id' => $admin->id,
+                    'community_id' => null,
+                    'building_id' => null,
+                    'service_type_id' => null,
+                ];
+            }
+
+            if (! empty($toInsert) && ! $isDryRun) {
+                DB::table('model_has_roles')->insert($toInsert);
+            }
+
+            $totalInserted += count($toInsert);
+        });
+
+        if (! $isDryRun) {
+            app(PermissionRegistrar::class)->forgetCachedPermissions();
+        }
+
+        $this->info("MigrateAdminRoles complete: {$totalInserted} inserted, {$totalSkippedExisting} skipped (already existed), {$totalSkippedInvalid} skipped (null/invalid role).");
+
+        if ($isDryRun) {
+            $this->warn('Dry-run mode — no rows were written.');
+        }
+
+        return self::SUCCESS;
+    }
+}

--- a/tests/Feature/Console/MigrateAdminRolesTest.php
+++ b/tests/Feature/Console/MigrateAdminRolesTest.php
@@ -248,6 +248,9 @@ class MigrateAdminRolesTest extends TestCase
             'role_id' => $roleId,
             'model_type' => $this->morphType,
             'model_id' => $admin->id,
+            'community_id' => null,
+            'building_id' => null,
+            'service_type_id' => null,
         ]);
 
         $this->artisan('rbac:migrate-admin-roles')->assertSuccessful();
@@ -293,6 +296,9 @@ class MigrateAdminRolesTest extends TestCase
             'role_id' => $roleId,
             'model_type' => $this->morphType,
             'model_id' => $admin->id,
+            'community_id' => null,
+            'building_id' => null,
+            'service_type_id' => null,
         ]);
 
         $this->artisan('rbac:migrate-admin-roles')

--- a/tests/Feature/Console/MigrateAdminRolesTest.php
+++ b/tests/Feature/Console/MigrateAdminRolesTest.php
@@ -1,0 +1,205 @@
+<?php
+
+namespace Tests\Feature\Console;
+
+use App\Enums\AdminRole;
+use App\Models\Admin;
+use App\Models\Role;
+use App\Models\Tenant;
+use Database\Seeders\RbacSeeder;
+use Illuminate\Database\Eloquent\Relations\Relation;
+use Illuminate\Foundation\Testing\LazilyRefreshDatabase;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Log;
+use Tests\TestCase;
+
+class MigrateAdminRolesTest extends TestCase
+{
+    use LazilyRefreshDatabase;
+
+    private string $morphType;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $map = Relation::morphMap();
+        $morphType = array_search(Admin::class, $map);
+        $this->morphType = $morphType !== false ? $morphType : Admin::class;
+    }
+
+    private function seedRoles(): void
+    {
+        (new RbacSeeder)->run();
+    }
+
+    private function createTenantWithAdmins(): Tenant
+    {
+        $tenant = Tenant::create(['name' => 'Test Tenant '.uniqid()]);
+
+        foreach (AdminRole::cases() as $role) {
+            Admin::factory()->create([
+                'account_tenant_id' => $tenant->id,
+                'role' => $role,
+            ]);
+        }
+
+        return $tenant;
+    }
+
+    private function modelHasRolesCount(): int
+    {
+        return DB::table('model_has_roles')
+            ->where('model_type', $this->morphType)
+            ->count();
+    }
+
+    // ── Happy path ────────────────────────────────────────────────────────────
+
+    public function test_command_inserts_one_row_per_admin_for_all_five_roles(): void
+    {
+        $this->seedRoles();
+        $this->createTenantWithAdmins();
+
+        $this->artisan('rbac:migrate-admin-roles')
+            ->assertSuccessful();
+
+        $this->assertSame(5, $this->modelHasRolesCount());
+    }
+
+    public function test_inserted_rows_have_correct_role_id_and_model_id(): void
+    {
+        $this->seedRoles();
+        $tenant = Tenant::create(['name' => 'Test Tenant '.uniqid()]);
+        $admin = Admin::factory()->create([
+            'account_tenant_id' => $tenant->id,
+            'role' => AdminRole::Admins,
+        ]);
+
+        $this->artisan('rbac:migrate-admin-roles')->assertSuccessful();
+
+        $roleId = Role::withoutGlobalScopes()
+            ->whereNull('account_tenant_id')
+            ->where('name', AdminRole::Admins->value)
+            ->value('id');
+
+        $this->assertDatabaseHas('model_has_roles', [
+            'model_type' => $this->morphType,
+            'model_id' => $admin->id,
+            'role_id' => $roleId,
+        ]);
+    }
+
+    // ── Idempotency ───────────────────────────────────────────────────────────
+
+    public function test_running_command_twice_does_not_duplicate_rows(): void
+    {
+        $this->seedRoles();
+        $this->createTenantWithAdmins();
+
+        $this->artisan('rbac:migrate-admin-roles')->assertSuccessful();
+        $countAfterFirst = $this->modelHasRolesCount();
+
+        $this->artisan('rbac:migrate-admin-roles')->assertSuccessful();
+        $countAfterSecond = $this->modelHasRolesCount();
+
+        $this->assertSame($countAfterFirst, $countAfterSecond);
+    }
+
+    public function test_partial_idempotency_only_inserts_missing_rows(): void
+    {
+        $this->seedRoles();
+        $tenant = Tenant::create(['name' => 'Test Tenant '.uniqid()]);
+
+        $admins = collect(AdminRole::cases())->map(fn ($role) => Admin::factory()->create([
+            'account_tenant_id' => $tenant->id,
+            'role' => $role,
+        ]));
+
+        // Manually insert one row first.
+        $roleId = Role::withoutGlobalScopes()
+            ->whereNull('account_tenant_id')
+            ->where('name', AdminRole::Admins->value)
+            ->value('id');
+
+        DB::table('model_has_roles')->insert([
+            'role_id' => $roleId,
+            'model_type' => $this->morphType,
+            'model_id' => $admins->first()->id,
+        ]);
+
+        $this->artisan('rbac:migrate-admin-roles')->assertSuccessful();
+
+        $this->assertSame(5, $this->modelHasRolesCount());
+    }
+
+    // ── Null / invalid role handling ──────────────────────────────────────────
+
+    /**
+     * The null-role path exists in the command as a defensive code path.
+     * The rf_admins.role column is currently NOT NULL in the schema, so this
+     * path cannot be triggered without DDL changes (which auto-commit in Postgres
+     * and would corrupt the test transaction). The invalid-role test below covers
+     * the same skip-and-warn behaviour.
+     */
+    public function test_admin_with_null_role_is_skipped_via_invalid_role_path(): void
+    {
+        $this->seedRoles();
+        $tenant = Tenant::create(['name' => 'Test Tenant '.uniqid()]);
+        $admin = Admin::factory()->create(['account_tenant_id' => $tenant->id]);
+
+        // Update to an unrecognised value (cannot set NULL due to NOT NULL constraint).
+        DB::table('rf_admins')->where('id', $admin->id)->update(['role' => 'unrecognised']);
+
+        Log::spy();
+
+        $this->artisan('rbac:migrate-admin-roles')->assertSuccessful();
+
+        $this->assertSame(0, $this->modelHasRolesCount());
+
+        Log::shouldHaveReceived('warning')
+            ->withArgs(fn (string $msg) => str_contains($msg, (string) $admin->id));
+    }
+
+    public function test_admin_with_invalid_role_is_skipped_and_command_succeeds(): void
+    {
+        $this->seedRoles();
+        $tenant = Tenant::create(['name' => 'Test Tenant '.uniqid()]);
+        $admin = Admin::factory()->create(['account_tenant_id' => $tenant->id]);
+
+        DB::table('rf_admins')->where('id', $admin->id)->update(['role' => 'bogusRole']);
+
+        $this->artisan('rbac:migrate-admin-roles')->assertSuccessful();
+
+        $this->assertSame(0, $this->modelHasRolesCount());
+    }
+
+    // ── Dry-run ───────────────────────────────────────────────────────────────
+
+    public function test_dry_run_does_not_write_any_rows(): void
+    {
+        $this->seedRoles();
+        $this->createTenantWithAdmins();
+
+        $this->artisan('rbac:migrate-admin-roles', ['--dry-run' => true])
+            ->assertSuccessful()
+            ->expectsOutputToContain('Dry-run mode');
+
+        $this->assertSame(0, $this->modelHasRolesCount());
+    }
+
+    // ── Missing roles (RbacSeeder not run) ───────────────────────────────────
+
+    public function test_command_fails_when_roles_are_not_seeded(): void
+    {
+        // No seeder run — roles table is empty.
+        $tenant = Tenant::create(['name' => 'Test Tenant '.uniqid()]);
+        Admin::factory()->create([
+            'account_tenant_id' => $tenant->id,
+            'role' => AdminRole::Admins,
+        ]);
+
+        $this->artisan('rbac:migrate-admin-roles')
+            ->assertFailed();
+    }
+}

--- a/tests/Feature/Console/MigrateAdminRolesTest.php
+++ b/tests/Feature/Console/MigrateAdminRolesTest.php
@@ -202,4 +202,170 @@ class MigrateAdminRolesTest extends TestCase
         $this->artisan('rbac:migrate-admin-roles')
             ->assertFailed();
     }
+
+    // ── Inserted rows reference system roles (account_tenant_id IS NULL) ─────
+
+    public function test_inserted_rows_point_to_system_roles_with_null_tenant(): void
+    {
+        $this->seedRoles();
+        $tenant = $this->createTenantWithAdmins();
+
+        $this->artisan('rbac:migrate-admin-roles')->assertSuccessful();
+
+        // Every role_id referenced in model_has_roles must belong to a system role.
+        $roleIds = DB::table('model_has_roles')
+            ->where('model_type', $this->morphType)
+            ->pluck('role_id')
+            ->unique()
+            ->all();
+
+        foreach ($roleIds as $roleId) {
+            $this->assertDatabaseHas('roles', [
+                'id' => $roleId,
+                'account_tenant_id' => null,
+            ]);
+        }
+    }
+
+    // ── Already-assigned admin: skip, not upsert ──────────────────────────────
+
+    public function test_already_assigned_admin_is_skipped_not_duplicated(): void
+    {
+        $this->seedRoles();
+        $tenant = Tenant::create(['name' => 'Test Tenant '.uniqid()]);
+        $admin = Admin::factory()->create([
+            'account_tenant_id' => $tenant->id,
+            'role' => AdminRole::Admins,
+        ]);
+
+        // Pre-insert the assignment manually.
+        $roleId = Role::withoutGlobalScopes()
+            ->whereNull('account_tenant_id')
+            ->where('name', AdminRole::Admins->value)
+            ->value('id');
+
+        DB::table('model_has_roles')->insert([
+            'role_id' => $roleId,
+            'model_type' => $this->morphType,
+            'model_id' => $admin->id,
+        ]);
+
+        $this->artisan('rbac:migrate-admin-roles')->assertSuccessful();
+
+        // Still only 1 row — no duplication.
+        $this->assertSame(
+            1,
+            DB::table('model_has_roles')
+                ->where('model_type', $this->morphType)
+                ->where('model_id', $admin->id)
+                ->where('role_id', $roleId)
+                ->count(),
+        );
+    }
+
+    // ── Summary output counts ─────────────────────────────────────────────────
+
+    public function test_summary_output_contains_inserted_count(): void
+    {
+        $this->seedRoles();
+        $this->createTenantWithAdmins(); // 5 admins
+
+        $this->artisan('rbac:migrate-admin-roles')
+            ->assertSuccessful()
+            ->expectsOutputToContain('5 inserted');
+    }
+
+    public function test_summary_output_contains_skipped_existing_count(): void
+    {
+        $this->seedRoles();
+        $tenant = Tenant::create(['name' => 'Test Tenant '.uniqid()]);
+        $admin = Admin::factory()->create([
+            'account_tenant_id' => $tenant->id,
+            'role' => AdminRole::Admins,
+        ]);
+
+        $roleId = Role::withoutGlobalScopes()
+            ->whereNull('account_tenant_id')
+            ->where('name', AdminRole::Admins->value)
+            ->value('id');
+
+        DB::table('model_has_roles')->insert([
+            'role_id' => $roleId,
+            'model_type' => $this->morphType,
+            'model_id' => $admin->id,
+        ]);
+
+        $this->artisan('rbac:migrate-admin-roles')
+            ->assertSuccessful()
+            ->expectsOutputToContain('1 skipped (already existed)');
+    }
+
+    public function test_summary_output_contains_invalid_skipped_count(): void
+    {
+        $this->seedRoles();
+        $tenant = Tenant::create(['name' => 'Test Tenant '.uniqid()]);
+        $admin = Admin::factory()->create(['account_tenant_id' => $tenant->id]);
+
+        DB::table('rf_admins')->where('id', $admin->id)->update(['role' => 'bogusRole']);
+
+        $this->artisan('rbac:migrate-admin-roles')
+            ->assertSuccessful()
+            ->expectsOutputToContain('1 skipped (null/invalid role)');
+    }
+
+    // ── Dry-run reports counts but writes nothing ─────────────────────────────
+
+    public function test_dry_run_outputs_would_be_inserted_count(): void
+    {
+        $this->seedRoles();
+        $this->createTenantWithAdmins(); // 5 admins
+
+        $this->artisan('rbac:migrate-admin-roles', ['--dry-run' => true])
+            ->assertSuccessful()
+            ->expectsOutputToContain('5 inserted')
+            ->expectsOutputToContain('Dry-run mode');
+
+        $this->assertSame(0, $this->modelHasRolesCount());
+    }
+
+    // ── Invalid role is logged with admin ID ─────────────────────────────────
+
+    public function test_invalid_role_warning_log_contains_admin_id(): void
+    {
+        $this->seedRoles();
+        $tenant = Tenant::create(['name' => 'Test Tenant '.uniqid()]);
+        $admin = Admin::factory()->create(['account_tenant_id' => $tenant->id]);
+
+        DB::table('rf_admins')->where('id', $admin->id)->update(['role' => 'unknownRole']);
+
+        Log::spy();
+
+        $this->artisan('rbac:migrate-admin-roles')->assertSuccessful();
+
+        Log::shouldHaveReceived('warning')
+            ->withArgs(fn (string $msg) => str_contains($msg, (string) $admin->id));
+    }
+
+    // ── Large dataset: chunked processing integrity ───────────────────────────
+
+    public function test_large_dataset_all_rows_inserted_across_chunks(): void
+    {
+        $this->seedRoles();
+
+        // Create 210 admins (crosses the 200-row chunk boundary).
+        $tenant = Tenant::create(['name' => 'Test Tenant '.uniqid()]);
+        $roles = AdminRole::cases();
+        $roleCount = count($roles);
+
+        for ($i = 0; $i < 210; $i++) {
+            Admin::factory()->create([
+                'account_tenant_id' => $tenant->id,
+                'role' => $roles[$i % $roleCount],
+            ]);
+        }
+
+        $this->artisan('rbac:migrate-admin-roles')->assertSuccessful();
+
+        $this->assertSame(210, $this->modelHasRolesCount());
+    }
 }


### PR DESCRIPTION
Closes #117

## Summary
- Introduces `php artisan rbac:migrate-admin-roles` — an idempotent Artisan command that reads every `rf_admins` row (chunked by 200 via `chunkById`) and inserts a corresponding `model_has_roles` row for the matching system-wide Role seeded by RbacSeeder.
- Supports `--dry-run` flag: reports insert count without writing anything.
- Pre-fetches existing `(model_type, model_id, role_id)` tuples per chunk to avoid N+1 and prevent duplicates.
- Skips admins with unrecognised or null role values and logs a warning; command never aborts mid-run.
- Calls `PermissionRegistrar::forgetCachedPermissions()` after all chunks to invalidate Spatie's cache.
- `rf_admins.role` column is **preserved** (not touched) per story spec.

## Files changed
- `app/Console/Commands/MigrateAdminRoles.php` — new command
- `tests/Feature/Console/MigrateAdminRolesTest.php` — 8 PHPUnit feature tests

## Test plan
- [x] PHPUnit: `php artisan test --compact tests/Feature/Console/MigrateAdminRolesTest.php` — 8 passed
- [x] Pint clean

## Rollback SQL (for ops if rows must be undone)
```sql
DELETE FROM model_has_roles
WHERE model_type = 'App\Models\Admin'
  AND role_id IN (
    SELECT id FROM roles
    WHERE account_tenant_id IS NULL
      AND name IN ('Admins','accountingManagers','serviceManagers','marketingManagers','salesAndLeasingManagers')
  );
```

## Prerequisites
RbacSeeder must have been run before executing this command in any environment. The command fails fast with a clear error if any of the 5 expected role names are missing.