### PR TITLE
feat(auth): Fortify gap audit — enable updateProfileInformation, updatePasswords, add locale/avatar_path

### DIFF
--- a/.claude/agent-memory/engineer/parallel-plan.md
+++ b/.claude/agent-memory/engineer/parallel-plan.md
@@ -1,0 +1,198 @@
+# Parallel Implementation Plan
+
+2-instance strategy: opencode + Claude Code working simultaneously on 170 stories.
+Base: `1.x`. Worktrees: `.claude/worktrees/opencode/` and `.claude/worktrees/claude-code/`.
+
+## Instance A — opencode (~87 stories)
+
+### Phase 0 — Infrastructure (sequential, blocks all tracks)
+- [ ] #243 — Auth Fortify gap audit
+- [ ] #199 — Documents data model
+- [ ] #224 — Settings ownership matrix
+
+### Phase 1 — Auth (9 stories)
+- [ ] #236 — Password reset
+- [ ] #237 — Email verification (parallel with #236)
+- [ ] #238 — Two-factor authentication (parallel with #236)
+- [ ] #239 — Session management
+- [ ] #240 — Profile self-service (parallel with #239)
+- [ ] #241 — Password confirmation (parallel with #239)
+- [ ] #244 — Logout
+- [ ] #245 — 2FA recovery codes
+- [ ] #242 — Admin user management
+
+### Phase 1 — Documents (9 stories)
+- [ ] #200 — Create & version document templates
+- [ ] #201 — Preview generated document
+- [ ] #202 — Generate document from template
+- [ ] #203 — E-signature flow
+- [ ] #204 — Download generated/signed docs
+- [ ] #205 — ExcelSheet import template (parallel with #206)
+- [ ] #206 — Bulk data export to Excel (parallel with #205)
+- [ ] #207 — Document template format decision gate
+- [ ] #208 — Historical version pinning
+
+### Phase 2-3 — Settings (8 stories)
+- [ ] #226 — Contract types (parallel #227..#231)
+- [ ] #227 — InvoiceSetting (parallel)
+- [ ] #228 — Regional settings (parallel)
+- [ ] #229 — Form templates (parallel)
+- [ ] #230 — ServiceSetting (parallel)
+- [ ] #231 — Notification preferences (parallel)
+- [ ] #232 — App appearance
+- [ ] #233 — Settings audit trail
+
+### Phase 2-3 — Communication (12 stories)
+- [ ] #279 — Data model: gaps + Complaint + Suggestion + DirectoryEntry
+- [ ] #280 — Announcement scheduling + targeting
+- [ ] #281 — Read-receipt tracking (parallel with #282)
+- [ ] #282 — Resident announcements feed (parallel with #281)
+- [ ] #283 — Resident submits complaint
+- [ ] #284 — Admin triages complaint queue
+- [ ] #285 — Complaint→ServiceRequest conversion
+- [ ] #286 — Complaint analytics
+- [ ] #287 — Resident suggestion + upvote (parallel with #288)
+- [ ] #288 — Admin responds to suggestions (parallel with #287)
+- [ ] #289 — Admin creates community directory
+- [ ] #290 — Resident browses directory
+
+### Phase 2-3 — Contacts (9 stories)
+- [ ] #149 — KYC documents on Resident (parallel #150..#152)
+- [ ] #150 — Unit Owner contacts (parallel)
+- [ ] #151 — Dependent contacts (parallel)
+- [ ] #152 — Professional contacts (parallel)
+- [ ] #153 — Bulk import contacts from Excel
+- [ ] #154 — 360° activity history
+- [ ] #155 — Archive/merge/reactivate
+- [ ] #156 — Contacts list with search/filter/export
+- [ ] #157 — Migrate existing residents/owners to unified Contacts
+
+### Phase 2-3 — Properties (10 stories)
+- [ ] #158 — Unit lifecycle state machine
+- [ ] #159 — Unit status history
+- [ ] #166 — Building metadata management
+- [ ] #168 — Unit detail page
+- [ ] #160 — Bulk import units (parallel with #161)
+- [ ] #161 — Import error review + re-attempt (parallel with #160)
+- [ ] #162 — Photo management
+- [ ] #163 — Global unit search
+- [ ] #164 — Export filtered units to Excel
+- [ ] #167 — Bulk status change
+
+### Phase 2-3 — Admin (13 stories)
+- [ ] #291 — Data model: AccountSubscription, Lead, etc.
+- [ ] #292 — Subscription overview (parallel #293, #294)
+- [ ] #293 — Plan change request (parallel)
+- [ ] #294 — Billing history (parallel)
+- [ ] #295 — Seat management
+- [ ] #296 — Leads list
+- [ ] #297 — Lead detail
+- [ ] #298 — Lead import
+- [ ] #299 — Lead→Contact conversion
+- [ ] #300 — Owner registration queue
+- [ ] #301 — Feature flags
+- [ ] #302 — Operations dashboard
+- [ ] #131 — RBAC audit log
+
+### Phase 2-3 — Marketplace (14 stories)
+- [ ] #265 — Data model: MarketplaceUnit, Offer, Visit
+- [ ] #266 — Listing eligibility
+- [ ] #267 — Seller creates listing
+- [ ] #268 — Seller manages listings
+- [ ] #269 — Buyer browses listings
+- [ ] #270 — Buyer submits inquiry
+- [ ] #271 — Seller manages inquiry queue
+- [ ] #272 — Buyer requests visit
+- [ ] #273 — Seller records visit outcome
+- [ ] #274 — Buyer submits offer
+- [ ] #275 — Seller accepts/counters/rejects
+- [ ] #276 — Offer→Lease quote trigger
+- [ ] #277 — Featured listings + promotions
+- [ ] #278 — Conversion funnel analytics
+
+---
+
+## Instance B — Claude Code (~84 stories)
+
+### Phase 1 — Leasing + Accounting (30 stories)
+- Leasing: #169→#170→#171→#172→#173→#175→#176→#177∥#178∥#179→#180→#181→#182→#183→#184
+  (15 stories)
+- Accounting: #185→#186∥#187→#188→#189→#190→#191→#192→#193→#194→#195→#196→#197→#198
+  (14 stories)
+- Note: #175+#188 must be co-designed; #176 blocked by Documents #202/#203
+
+### Phase 1 — Service Requests (15 stories)
+- #222→#209→#210→#211→#212→#213→#214→#215→#220→#216→#217→#218→#219→#221→#223
+
+### Phase 1 — Facilities (11 stories)
+- #246→#247→#248→#249→#250→#251→#252→#253→#254→#255→#256
+- Note: #253 blocked by Documents #202/#203; #254 blocked by Accounting #190
+
+### Phase 1 — Visitor Access (8 stories)
+- #257→#258→#259→#260→#261→#262→#263→#264
+
+### Phase 2-3 — Reports + PowerBI (20 stories)
+- Reports: #303→#304∥#305∥#306→#307→#308→#309→#310→#311→#312→#313 (11)
+- PowerBI: #314→#315→#316→#317→#318→#319→#320→#321→#322 (9)
+
+---
+
+## Shared Protocol
+
+### Claim a story
+```bash
+gh issue edit <N> --repo mabumusa1/facilities-management \
+  --remove-label "state:ready-for-impl" \
+  --add-label "state:in-progress,agent:engineer" \
+  --assignee @me
+```
+
+### Create worktree + branch
+```bash
+# opencode
+git worktree add -b <area>/<slug>-#<N> .claude/worktrees/opencode
+
+# Claude Code
+git worktree add -b <area>/<slug>-#<N> .claude/worktrees/claude-code
+```
+
+### Pre-commit checklist
+```bash
+php artisan wayfinder:generate
+vendor/bin/pint --dirty --format agent
+php artisan test --compact tests/Feature/<StoryTest>.php
+```
+
+### Open PR + transition state
+```bash
+gh pr create --repo mabumusa1/facilities-management --base 1.x \
+  --title "feat: <area>: <title>" --body "Closes #<N>"
+gh issue edit <N> --add-label "state:in-review" --remove-label "state:in-progress"
+```
+
+### After PR merge — cleanup worktree
+```bash
+git worktree remove .claude/worktrees/<instance> --force
+```
+
+---
+
+## Phase Gates
+
+| Gate | Trigger | Action |
+|------|---------|--------|
+| Phase 0→1 | #243, #199, #224 merged | Both instances launch Phase 1 tracks |
+| B: #169 merged | Leasing data model done | Start accounting #185 in parallel |
+| B: #175 merged | Lease activation done | Start accounting #188 |
+| B: #222 merged | SR data model done | Start SR features #209→ |
+| A: #200 merged | Document templates done | Start document generation #201→ |
+| Phase 1→2 | All Phase 1 complete | Launch Phase 2-3 tracks |
+
+## Conflict Guarantees
+
+- Zero file overlap between Instance A and Instance B tracks
+- opencode areas: auth, documents, communication, contacts, properties, settings, admin, marketplace
+- Claude Code areas: leasing, accounting, service-requests, facilities, visitor-access, reports
+- Migration tables are area-segregated
+- Routes are area-prefixed
+- Auth (User) and Settings shared models: opencode modifies them first; Claude Code reads only

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Admin → Roles — list, search, create, edit, and delete custom roles with bilingual English/Arabic names ([#122](https://github.com/mabumusa1/facilities-management/pull/122))
 - Admin → Roles — permission matrix editor (31 subjects × 6 actions) with presets and a "View is required when any other action is enabled" rule ([#123](https://github.com/mabumusa1/facilities-management/pull/123))
 - Admin → Users — drawer-based role assignment with community, building, and service-type scope selectors ([#124](https://github.com/mabumusa1/facilities-management/pull/124))
+- Enabled Fortify update-profile-information and update-passwords features for future auth stories ([#331](https://github.com/mabumusa1/facilities-management/pull/331))
+- Added locale and avatar_path columns to users table for profile self-service ([#331](https://github.com/mabumusa1/facilities-management/pull/331))
 
 ### Changed
 

--- a/app/Actions/Fortify/UpdateUserPassword.php
+++ b/app/Actions/Fortify/UpdateUserPassword.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace App\Actions\Fortify;
+
+use App\Concerns\PasswordValidationRules;
+use App\Models\User;
+use Illuminate\Support\Facades\Validator;
+use Laravel\Fortify\Contracts\UpdatesUserPasswords;
+
+class UpdateUserPassword implements UpdatesUserPasswords
+{
+    use PasswordValidationRules;
+
+    /**
+     * Validate and update the user's password.
+     *
+     * @param  array<string, string>  $input
+     */
+    public function update(User $user, array $input): void
+    {
+        Validator::make($input, [
+            'current_password' => ['required', 'string', 'current_password:web'],
+            'password' => $this->passwordRules(),
+        ], [
+            'current_password.current_password' => __('The provided password does not match your current password.'),
+        ])->validateWithBag('updatePassword');
+
+        $user->forceFill([
+            'password' => $input['password'],
+        ])->save();
+    }
+}

--- a/app/Actions/Fortify/UpdateUserProfileInformation.php
+++ b/app/Actions/Fortify/UpdateUserProfileInformation.php
@@ -1,0 +1,59 @@
+<?php
+
+namespace App\Actions\Fortify;
+
+use App\Models\User;
+use Illuminate\Contracts\Auth\MustVerifyEmail;
+use Illuminate\Support\Facades\Validator;
+use Illuminate\Validation\Rule;
+use Laravel\Fortify\Contracts\UpdatesUserProfileInformation;
+
+class UpdateUserProfileInformation implements UpdatesUserProfileInformation
+{
+    /**
+     * Validate and update the given user's profile information.
+     *
+     * @param  array<string, mixed>  $input
+     */
+    public function update(User $user, array $input): void
+    {
+        Validator::make($input, [
+            'name' => ['required', 'string', 'max:255'],
+            'email' => ['required', 'string', 'email', 'max:255', Rule::unique('users')->ignore($user->id)],
+            'phone_number' => ['nullable', 'string', 'max:20'],
+            'locale' => ['nullable', 'string', 'max:5'],
+            'avatar_path' => ['nullable', 'string', 'max:2048'],
+        ])->validateWithBag('updateProfileInformation');
+
+        if ($input['email'] !== $user->email && $user instanceof MustVerifyEmail) {
+            $this->updateVerifiedUser($user, $input);
+        } else {
+            $user->forceFill([
+                'name' => $input['name'],
+                'email' => $input['email'],
+                'phone_number' => $input['phone_number'] ?? $user->phone_number,
+                'locale' => $input['locale'] ?? $user->locale,
+                'avatar_path' => $input['avatar_path'] ?? $user->avatar_path,
+            ])->save();
+        }
+    }
+
+    /**
+     * Update the given verified user's profile information.
+     *
+     * @param  array<string, string>  $input
+     */
+    protected function updateVerifiedUser(User $user, array $input): void
+    {
+        $user->forceFill([
+            'name' => $input['name'],
+            'email' => $input['email'],
+            'email_verified_at' => null,
+            'phone_number' => $input['phone_number'] ?? $user->phone_number,
+            'locale' => $input['locale'] ?? $user->locale,
+            'avatar_path' => $input['avatar_path'] ?? $user->avatar_path,
+        ])->save();
+
+        $user->sendEmailVerificationNotification();
+    }
+}

--- a/app/Providers/FortifyServiceProvider.php
+++ b/app/Providers/FortifyServiceProvider.php
@@ -4,6 +4,8 @@ namespace App\Providers;
 
 use App\Actions\Fortify\CreateNewUser;
 use App\Actions\Fortify\ResetUserPassword;
+use App\Actions\Fortify\UpdateUserPassword;
+use App\Actions\Fortify\UpdateUserProfileInformation;
 use App\Http\Responses\LoginResponse;
 use App\Http\Responses\RegisterResponse;
 use Illuminate\Cache\RateLimiting\Limit;
@@ -45,6 +47,8 @@ class FortifyServiceProvider extends ServiceProvider
     {
         Fortify::resetUserPasswordsUsing(ResetUserPassword::class);
         Fortify::createUsersUsing(CreateNewUser::class);
+        Fortify::updateUserProfileInformationUsing(UpdateUserProfileInformation::class);
+        Fortify::updateUserPasswordsUsing(UpdateUserPassword::class);
     }
 
     /**

--- a/config/fortify.php
+++ b/config/fortify.php
@@ -147,6 +147,8 @@ return [
         Features::registration(),
         Features::resetPasswords(),
         Features::emailVerification(),
+        Features::updateProfileInformation(),
+        Features::updatePasswords(),
         Features::twoFactorAuthentication([
             'confirm' => true,
             'confirmPassword' => true,

--- a/database/migrations/2026_04_25_121258_add_profile_columns_to_users_table.php
+++ b/database/migrations/2026_04_25_121258_add_profile_columns_to_users_table.php
@@ -1,0 +1,29 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('users', function (Blueprint $table) {
+            $table->string('locale', 5)->nullable();
+            $table->string('avatar_path')->nullable();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('users', function (Blueprint $table) {
+            $table->dropColumn(['locale', 'avatar_path']);
+        });
+    }
+};

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -10,6 +10,7 @@ A plain-language running list of user-visible changes. For the developer-facing 
 
 ## Unreleased
 
+<<<<<<< HEAD
 ### Facility availability and waitlist — April 25, 2026
 
 The groundwork for facility bookings is now in place. Property Managers will soon be able to set opening hours for each facility on a per-day basis, and residents will be able to join a waitlist when a slot is full.
@@ -73,6 +74,10 @@ Every service request now has a unique reference code in the format `SR-YYYY-NNN
 This release also puts in place the infrastructure for two features coming soon: a per-request messaging thread (resident and staff chat, with internal-only notes) and an activity timeline that logs every status change and key action on a request.
 
 Learn more: [Service request reference codes](./guides/service-requests/service-request-reference-codes.md).
+
+### Backend — April 25, 2026
+
+Backend: Fortify authentication features expanded to support upcoming profile management and password self-service.
 
 ### Resident contacts — April 25, 2026
 

--- a/tests/Feature/Feature/FortifyGapAuditTest.php
+++ b/tests/Feature/Feature/FortifyGapAuditTest.php
@@ -1,0 +1,66 @@
+<?php
+
+namespace Tests\Feature\Feature;
+
+use Illuminate\Support\Facades\Route;
+use Tests\TestCase;
+
+class FortifyGapAuditTest extends TestCase
+{
+    public function test_fortify_features_are_enabled(): void
+    {
+        $features = config('fortify.features');
+
+        $expected = [
+            'registration',
+            'reset-passwords',
+            'email-verification',
+            'update-profile-information',
+            'update-passwords',
+            'two-factor-authentication',
+        ];
+
+        foreach ($expected as $feature) {
+            $this->assertContains($feature, $features, "Feature '{$feature}' is not enabled");
+        }
+    }
+
+    public function test_fortify_update_profile_information_route_is_registered(): void
+    {
+        $this->assertTrue(
+            Route::getRoutes()->hasNamedRoute('user-profile-information.update'),
+            'Route user-profile-information.update is not registered'
+        );
+    }
+
+    public function test_fortify_update_password_route_is_registered(): void
+    {
+        $this->assertTrue(
+            Route::getRoutes()->hasNamedRoute('user-password.update'),
+            'Route user-password.update is not registered'
+        );
+    }
+
+    public function test_fortify_two_factor_routes_are_registered(): void
+    {
+        $this->assertTrue(Route::getRoutes()->hasNamedRoute('two-factor.login'));
+        $this->assertTrue(Route::getRoutes()->hasNamedRoute('two-factor.enable'));
+        $this->assertTrue(Route::getRoutes()->hasNamedRoute('two-factor.disable'));
+        $this->assertTrue(Route::getRoutes()->hasNamedRoute('two-factor.qr-code'));
+        $this->assertTrue(Route::getRoutes()->hasNamedRoute('two-factor.recovery-codes'));
+        $this->assertTrue(Route::getRoutes()->hasNamedRoute('two-factor.secret-key'));
+    }
+
+    public function test_fortify_password_confirmation_routes_are_registered(): void
+    {
+        $this->assertTrue(Route::getRoutes()->hasNamedRoute('password.confirm'));
+        $this->assertTrue(Route::getRoutes()->hasNamedRoute('password.confirmation'));
+    }
+
+    public function test_password_reset_routes_are_registered(): void
+    {
+        $this->assertTrue(Route::getRoutes()->hasNamedRoute('password.request'));
+        $this->assertTrue(Route::getRoutes()->hasNamedRoute('password.email'));
+        $this->assertTrue(Route::getRoutes()->hasNamedRoute('password.update'));
+    }
+}

--- a/tests/Feature/Feature/FortifyGapAuditTest.php
+++ b/tests/Feature/Feature/FortifyGapAuditTest.php
@@ -2,11 +2,24 @@
 
 namespace Tests\Feature\Feature;
 
+use App\Models\User;
+use Illuminate\Contracts\Auth\MustVerifyEmail;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Hash;
 use Illuminate\Support\Facades\Route;
 use Tests\TestCase;
 
 class FortifyGapAuditTest extends TestCase
 {
+    use RefreshDatabase;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->withoutVite();
+    }
+
     public function test_fortify_features_are_enabled(): void
     {
         $features = config('fortify.features');
@@ -62,5 +75,258 @@ class FortifyGapAuditTest extends TestCase
         $this->assertTrue(Route::getRoutes()->hasNamedRoute('password.request'));
         $this->assertTrue(Route::getRoutes()->hasNamedRoute('password.email'));
         $this->assertTrue(Route::getRoutes()->hasNamedRoute('password.update'));
+    }
+
+    public function test_user_can_update_profile_name(): void
+    {
+        $user = User::factory()->create(['name' => 'Original Name', 'email' => 'original@example.com']);
+
+        $response = $this->actingAs($user)->put('/user/profile-information', [
+            'name' => 'Updated Name',
+            'email' => 'original@example.com',
+        ]);
+
+        $response->assertSessionHasNoErrors();
+        $response->assertRedirect();
+
+        $user->refresh();
+        $this->assertSame('Updated Name', $user->name);
+        $this->assertSame('original@example.com', $user->email);
+    }
+
+    public function test_user_can_update_profile_email(): void
+    {
+        $user = User::factory()->create(['email' => 'original@example.com']);
+
+        $response = $this->actingAs($user)->put('/user/profile-information', [
+            'name' => $user->name,
+            'email' => 'new@example.com',
+        ]);
+
+        $response->assertSessionHasNoErrors();
+        $user->refresh();
+        $this->assertSame('new@example.com', $user->email);
+    }
+
+    public function test_profile_update_fails_when_name_is_missing(): void
+    {
+        $user = User::factory()->create();
+
+        $response = $this->actingAs($user)->put('/user/profile-information', [
+            'name' => '',
+            'email' => 'test@example.com',
+        ]);
+
+        $response->assertSessionHasErrors('name', 'updateProfileInformation');
+    }
+
+    public function test_profile_update_fails_when_email_is_missing(): void
+    {
+        $user = User::factory()->create();
+
+        $response = $this->actingAs($user)->put('/user/profile-information', [
+            'name' => 'Test User',
+            'email' => '',
+        ]);
+
+        $response->assertSessionHasErrors('email', 'updateProfileInformation');
+    }
+
+    public function test_profile_update_fails_with_duplicate_email(): void
+    {
+        User::factory()->create(['email' => 'existing@example.com']);
+        $user = User::factory()->create(['email' => 'current@example.com']);
+
+        $response = $this->actingAs($user)->put('/user/profile-information', [
+            'name' => 'Test User',
+            'email' => 'existing@example.com',
+        ]);
+
+        $response->assertSessionHasErrors('email', 'updateProfileInformation');
+    }
+
+    public function test_profile_update_fails_with_invalid_email_format(): void
+    {
+        $user = User::factory()->create();
+
+        $response = $this->actingAs($user)->put('/user/profile-information', [
+            'name' => 'Test User',
+            'email' => 'not-an-email',
+        ]);
+
+        $response->assertSessionHasErrors('email', 'updateProfileInformation');
+    }
+
+    public function test_user_can_update_locale_and_phone_number(): void
+    {
+        $user = User::factory()->create();
+
+        $response = $this->actingAs($user)->put('/user/profile-information', [
+            'name' => $user->name,
+            'email' => $user->email,
+            'locale' => 'ar',
+            'phone_number' => '1234567890',
+        ]);
+
+        $response->assertSessionHasNoErrors();
+        $user->refresh();
+        $this->assertSame('ar', $user->locale);
+        $this->assertSame('1234567890', $user->phone_number);
+    }
+
+    public function test_profile_update_validates_locale_max_length(): void
+    {
+        $user = User::factory()->create();
+
+        $response = $this->actingAs($user)->put('/user/profile-information', [
+            'name' => $user->name,
+            'email' => $user->email,
+            'locale' => str_repeat('x', 6),
+        ]);
+
+        $response->assertSessionHasErrors('locale', 'updateProfileInformation');
+    }
+
+    public function test_profile_update_validates_phone_number_max_length(): void
+    {
+        $user = User::factory()->create();
+
+        $response = $this->actingAs($user)->put('/user/profile-information', [
+            'name' => $user->name,
+            'email' => $user->email,
+            'phone_number' => str_repeat('0', 21),
+        ]);
+
+        $response->assertSessionHasErrors('phone_number', 'updateProfileInformation');
+    }
+
+    public function test_email_change_clears_verified_at_for_must_verify_email_user(): void
+    {
+        $user = new class extends User implements MustVerifyEmail
+        {
+            use \Illuminate\Auth\MustVerifyEmail;
+
+            protected $table = 'users';
+        };
+
+        $user->forceFill([
+            'name' => 'Original Name',
+            'email' => 'old@example.com',
+            'password' => Hash::make('password'),
+            'email_verified_at' => now(),
+        ])->save();
+
+        $this->assertTrue($user instanceof MustVerifyEmail);
+
+        $response = $this->actingAs($user)->put('/user/profile-information', [
+            'name' => $user->name,
+            'email' => 'new@example.com',
+        ]);
+
+        $response->assertSessionHasNoErrors();
+        $user->refresh();
+        $this->assertSame('new@example.com', $user->email);
+        $this->assertNull($user->email_verified_at);
+    }
+
+    public function test_user_can_update_password_with_correct_current_password(): void
+    {
+        $user = User::factory()->create();
+
+        $response = $this->actingAs($user)->put('/user/password', [
+            'current_password' => 'password',
+            'password' => 'new-password-123',
+            'password_confirmation' => 'new-password-123',
+        ]);
+
+        $response->assertSessionHasNoErrors();
+        $response->assertRedirect();
+
+        $user->refresh();
+        $this->assertTrue(Hash::check('new-password-123', $user->password));
+    }
+
+    public function test_password_update_fails_with_wrong_current_password(): void
+    {
+        $user = User::factory()->create();
+
+        $response = $this->actingAs($user)->put('/user/password', [
+            'current_password' => 'wrong-password',
+            'password' => 'new-password-123',
+            'password_confirmation' => 'new-password-123',
+        ]);
+
+        $response->assertSessionHasErrors('current_password', 'updatePassword');
+    }
+
+    public function test_password_update_fails_when_current_password_is_missing(): void
+    {
+        $user = User::factory()->create();
+
+        $response = $this->actingAs($user)->put('/user/password', [
+            'password' => 'new-password-123',
+            'password_confirmation' => 'new-password-123',
+        ]);
+
+        $response->assertSessionHasErrors('current_password', 'updatePassword');
+    }
+
+    public function test_password_update_fails_when_new_password_is_missing(): void
+    {
+        $user = User::factory()->create();
+
+        $response = $this->actingAs($user)->put('/user/password', [
+            'current_password' => 'password',
+            'password_confirmation' => 'new-password-123',
+        ]);
+
+        $response->assertSessionHasErrors('password', 'updatePassword');
+    }
+
+    public function test_password_update_fails_with_mismatched_confirmation(): void
+    {
+        $user = User::factory()->create();
+
+        $response = $this->actingAs($user)->put('/user/password', [
+            'current_password' => 'password',
+            'password' => 'new-password-123',
+            'password_confirmation' => 'different-password',
+        ]);
+
+        $response->assertSessionHasErrors('password', 'updatePassword');
+    }
+
+    public function test_password_update_fails_with_weak_new_password(): void
+    {
+        $user = User::factory()->create();
+
+        $response = $this->actingAs($user)->put('/user/password', [
+            'current_password' => 'password',
+            'password' => 'abc',
+            'password_confirmation' => 'abc',
+        ]);
+
+        $response->assertSessionHasErrors('password', 'updatePassword');
+    }
+
+    public function test_unauthenticated_user_cannot_update_profile(): void
+    {
+        $response = $this->put('/user/profile-information', [
+            'name' => 'Test',
+            'email' => 'test@example.com',
+        ]);
+
+        $response->assertRedirect();
+    }
+
+    public function test_unauthenticated_user_cannot_update_password(): void
+    {
+        $response = $this->put('/user/password', [
+            'current_password' => 'password',
+            'password' => 'new-password-123',
+            'password_confirmation' => 'new-password-123',
+        ]);
+
+        $response->assertRedirect();
     }
 }


### PR DESCRIPTION
Closes #243

## Summary
- Enabled `updateProfileInformation` and `updatePasswords` Fortify features in config
- Created `UpdateUserProfileInformation` action (validates name, email, phone_number, locale, avatar_path; handles MustVerifyEmail re-verification)
- Created `UpdateUserPassword` action (validates current_password, enforces password rules)
- Registered both new actions in `FortifyServiceProvider`
- Added `locale` (string, nullable) and `avatar_path` (string, nullable) columns on users table
- Added test verifying all Fortify routes (6 tests, 19 assertions)

## Verification
All 15 Fortify routes confirmed registered: password.*, user-profile-information.*, user-password.*, two-factor.*, verification.send