### PR TITLE
feat(documents): Document data model — Template, Version, Record, Signature entities

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Admin → Users — drawer-based role assignment with community, building, and service-type scope selectors ([#124](https://github.com/mabumusa1/facilities-management/pull/124))
 - Enabled Fortify update-profile-information and update-passwords features for future auth stories ([#331](https://github.com/mabumusa1/facilities-management/pull/331))
 - Added locale and avatar_path columns to users table for profile self-service ([#331](https://github.com/mabumusa1/facilities-management/pull/331))
+- Added Documents data model (templates, versions, records, signatures) for cross-domain document generation ([#332](https://github.com/mabumusa1/facilities-management/pull/332))
 
 ### Changed
 

--- a/app/Models/DocumentRecord.php
+++ b/app/Models/DocumentRecord.php
@@ -1,0 +1,52 @@
+<?php
+
+namespace App\Models;
+
+use App\Concerns\BelongsToAccountTenant;
+use Database\Factories\DocumentRecordFactory;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Database\Eloquent\Relations\HasMany;
+use Illuminate\Database\Eloquent\Relations\MorphTo;
+use Illuminate\Database\Eloquent\SoftDeletes;
+
+class DocumentRecord extends Model
+{
+    /** @use HasFactory<DocumentRecordFactory> */
+    use BelongsToAccountTenant, HasFactory, SoftDeletes;
+
+    protected $table = 'rf_document_records';
+
+    protected $fillable = [
+        'account_tenant_id',
+        'document_template_version_id',
+        'source_type',
+        'source_id',
+        'generated_at',
+        'file_path',
+        'status',
+    ];
+
+    protected function casts(): array
+    {
+        return [
+            'generated_at' => 'datetime',
+        ];
+    }
+
+    public function templateVersion(): BelongsTo
+    {
+        return $this->belongsTo(DocumentVersion::class, 'document_template_version_id');
+    }
+
+    public function source(): MorphTo
+    {
+        return $this->morphTo();
+    }
+
+    public function signatures(): HasMany
+    {
+        return $this->hasMany(DocumentSignature::class);
+    }
+}

--- a/app/Models/DocumentSignature.php
+++ b/app/Models/DocumentSignature.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace App\Models;
+
+use Database\Factories\DocumentSignatureFactory;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+class DocumentSignature extends Model
+{
+    /** @use HasFactory<DocumentSignatureFactory> */
+    use HasFactory;
+
+    protected $table = 'rf_document_signatures';
+
+    protected $fillable = [
+        'document_record_id',
+        'signer_name',
+        'signer_email',
+        'signed_at',
+        'ip_address',
+        'otp_verified_at',
+        'signed_file_path',
+    ];
+
+    protected function casts(): array
+    {
+        return [
+            'signed_at' => 'datetime',
+            'otp_verified_at' => 'datetime',
+        ];
+    }
+
+    public function documentRecord(): BelongsTo
+    {
+        return $this->belongsTo(DocumentRecord::class);
+    }
+}

--- a/app/Models/DocumentTemplate.php
+++ b/app/Models/DocumentTemplate.php
@@ -1,0 +1,51 @@
+<?php
+
+namespace App\Models;
+
+use App\Concerns\BelongsToAccountTenant;
+use Database\Factories\DocumentTemplateFactory;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Database\Eloquent\Relations\HasMany;
+use Illuminate\Database\Eloquent\SoftDeletes;
+
+class DocumentTemplate extends Model
+{
+    /** @use HasFactory<DocumentTemplateFactory> */
+    use BelongsToAccountTenant, HasFactory, SoftDeletes;
+
+    protected $table = 'rf_document_templates';
+
+    protected $fillable = [
+        'account_tenant_id',
+        'name',
+        'type',
+        'status',
+        'format',
+        'created_by',
+        'current_version_id',
+    ];
+
+    protected function casts(): array
+    {
+        return [
+            'name' => 'json',
+        ];
+    }
+
+    public function versions(): HasMany
+    {
+        return $this->hasMany(DocumentVersion::class);
+    }
+
+    public function currentVersion(): BelongsTo
+    {
+        return $this->belongsTo(DocumentVersion::class, 'current_version_id');
+    }
+
+    public function creator(): BelongsTo
+    {
+        return $this->belongsTo(User::class, 'created_by');
+    }
+}

--- a/app/Models/DocumentVersion.php
+++ b/app/Models/DocumentVersion.php
@@ -1,0 +1,51 @@
+<?php
+
+namespace App\Models;
+
+use Database\Factories\DocumentVersionFactory;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Database\Eloquent\Relations\HasMany;
+
+class DocumentVersion extends Model
+{
+    /** @use HasFactory<DocumentVersionFactory> */
+    use HasFactory;
+
+    protected $table = 'rf_document_versions';
+
+    protected $fillable = [
+        'document_template_id',
+        'version_number',
+        'body',
+        'file_path',
+        'merge_fields',
+        'published_at',
+        'created_by',
+    ];
+
+    protected function casts(): array
+    {
+        return [
+            'version_number' => 'integer',
+            'merge_fields' => 'json',
+            'published_at' => 'datetime',
+        ];
+    }
+
+    public function template(): BelongsTo
+    {
+        return $this->belongsTo(DocumentTemplate::class, 'document_template_id');
+    }
+
+    public function creator(): BelongsTo
+    {
+        return $this->belongsTo(User::class, 'created_by');
+    }
+
+    public function records(): HasMany
+    {
+        return $this->hasMany(DocumentRecord::class, 'document_template_version_id');
+    }
+}

--- a/database/factories/DocumentRecordFactory.php
+++ b/database/factories/DocumentRecordFactory.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Models\DocumentRecord;
+use App\Models\DocumentVersion;
+use App\Models\Tenant;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+/**
+ * @extends Factory<DocumentRecord>
+ */
+class DocumentRecordFactory extends Factory
+{
+    protected $model = DocumentRecord::class;
+
+    public function definition(): array
+    {
+        return [
+            'account_tenant_id' => Tenant::factory(),
+            'document_template_version_id' => DocumentVersion::factory(),
+            'generated_at' => fake()->dateTime(),
+            'file_path' => fake()->filePath(),
+            'status' => fake()->randomElement(['draft', 'sent', 'signed', 'archived']),
+        ];
+    }
+}

--- a/database/factories/DocumentSignatureFactory.php
+++ b/database/factories/DocumentSignatureFactory.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Models\DocumentRecord;
+use App\Models\DocumentSignature;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+/**
+ * @extends Factory<DocumentSignature>
+ */
+class DocumentSignatureFactory extends Factory
+{
+    protected $model = DocumentSignature::class;
+
+    public function definition(): array
+    {
+        return [
+            'document_record_id' => DocumentRecord::factory(),
+            'signer_name' => fake()->name(),
+            'signer_email' => fake()->safeEmail(),
+            'signed_at' => fake()->dateTime(),
+            'ip_address' => fake()->ipv4(),
+            'otp_verified_at' => fake()->dateTime(),
+            'signed_file_path' => fake()->filePath(),
+        ];
+    }
+}

--- a/database/factories/DocumentTemplateFactory.php
+++ b/database/factories/DocumentTemplateFactory.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Models\DocumentTemplate;
+use App\Models\Tenant;
+use App\Models\User;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+/**
+ * @extends Factory<DocumentTemplate>
+ */
+class DocumentTemplateFactory extends Factory
+{
+    protected $model = DocumentTemplate::class;
+
+    public function definition(): array
+    {
+        return [
+            'account_tenant_id' => Tenant::factory(),
+            'name' => ['en' => fake()->unique()->word(), 'ar' => 'قالب'],
+            'type' => fake()->randomElement(['lease', 'booking', 'invoice', 'receipt', 'custom']),
+            'status' => fake()->randomElement(['draft', 'active', 'archived']),
+            'format' => fake()->randomElement(['word_upload', 'in_platform']),
+            'created_by' => User::factory(),
+        ];
+    }
+
+    public function active(): static
+    {
+        return $this->state(fn (array $attributes) => [
+            'status' => 'active',
+        ]);
+    }
+
+    public function draft(): static
+    {
+        return $this->state(fn (array $attributes) => [
+            'status' => 'draft',
+        ]);
+    }
+}

--- a/database/factories/DocumentVersionFactory.php
+++ b/database/factories/DocumentVersionFactory.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Models\DocumentTemplate;
+use App\Models\DocumentVersion;
+use App\Models\User;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+/**
+ * @extends Factory<DocumentVersion>
+ */
+class DocumentVersionFactory extends Factory
+{
+    protected $model = DocumentVersion::class;
+
+    public function definition(): array
+    {
+        return [
+            'document_template_id' => DocumentTemplate::factory(),
+            'version_number' => fake()->numberBetween(1, 10),
+            'body' => fake()->paragraph(),
+            'merge_fields' => ['recipient_name', 'date', 'amount'],
+            'published_at' => fake()->dateTime(),
+            'created_by' => User::factory(),
+        ];
+    }
+}

--- a/database/migrations/2026_04_25_124555_create_rf_document_templates_table.php
+++ b/database/migrations/2026_04_25_124555_create_rf_document_templates_table.php
@@ -1,0 +1,29 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('rf_document_templates', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('account_tenant_id')->constrained('tenants')->cascadeOnDelete();
+            $table->json('name');
+            $table->string('type');
+            $table->string('status')->default('draft');
+            $table->string('format')->default('word_upload');
+            $table->foreignId('created_by')->nullable()->constrained('users')->nullOnDelete();
+            $table->foreignId('current_version_id')->nullable();
+            $table->timestamps();
+            $table->softDeletes();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('rf_document_templates');
+    }
+};

--- a/database/migrations/2026_04_25_124555_create_rf_document_versions_table.php
+++ b/database/migrations/2026_04_25_124555_create_rf_document_versions_table.php
@@ -1,0 +1,30 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('rf_document_versions', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('document_template_id')->constrained('rf_document_templates')->cascadeOnDelete();
+            $table->unsignedInteger('version_number');
+            $table->text('body')->nullable();
+            $table->string('file_path')->nullable();
+            $table->json('merge_fields')->nullable();
+            $table->timestamp('published_at')->nullable();
+            $table->foreignId('created_by')->nullable()->constrained('users')->nullOnDelete();
+            $table->timestamps();
+
+            $table->unique(['document_template_id', 'version_number']);
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('rf_document_versions');
+    }
+};

--- a/database/migrations/2026_04_25_124556_create_rf_document_records_table.php
+++ b/database/migrations/2026_04_25_124556_create_rf_document_records_table.php
@@ -1,0 +1,28 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('rf_document_records', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('account_tenant_id')->constrained('tenants')->cascadeOnDelete();
+            $table->foreignId('document_template_version_id')->constrained('rf_document_versions')->cascadeOnDelete();
+            $table->nullableMorphs('source');
+            $table->timestamp('generated_at')->nullable();
+            $table->string('file_path')->nullable();
+            $table->string('status')->default('draft');
+            $table->timestamps();
+            $table->softDeletes();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('rf_document_records');
+    }
+};

--- a/database/migrations/2026_04_25_124557_create_rf_document_signatures_table.php
+++ b/database/migrations/2026_04_25_124557_create_rf_document_signatures_table.php
@@ -1,0 +1,28 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('rf_document_signatures', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('document_record_id')->constrained('rf_document_records')->cascadeOnDelete();
+            $table->string('signer_name');
+            $table->string('signer_email');
+            $table->timestamp('signed_at')->nullable();
+            $table->string('ip_address', 45)->nullable();
+            $table->timestamp('otp_verified_at')->nullable();
+            $table->string('signed_file_path')->nullable();
+            $table->timestamps();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('rf_document_signatures');
+    }
+};

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -78,6 +78,7 @@ Learn more: [Service request reference codes](./guides/service-requests/service-
 ### Backend — April 25, 2026
 
 Backend: Fortify authentication features expanded to support upcoming profile management and password self-service.
+Backend: New Documents infrastructure for contract, invoice, and receipt generation across Leasing, Facilities, and Accounting modules.
 
 ### Resident contacts — April 25, 2026
 

--- a/tests/Feature/Feature/Documents/DocumentDataModelTest.php
+++ b/tests/Feature/Feature/Documents/DocumentDataModelTest.php
@@ -1,0 +1,57 @@
+<?php
+
+namespace Tests\Feature\Feature\Documents;
+
+use Illuminate\Support\Facades\Schema;
+use Tests\TestCase;
+
+class DocumentDataModelTest extends TestCase
+{
+    public function test_document_templates_table_exists(): void
+    {
+        $this->assertTrue(Schema::hasTable('rf_document_templates'));
+        $this->assertTrue(Schema::hasColumns('rf_document_templates', [
+            'id', 'account_tenant_id', 'name', 'type', 'status', 'format',
+            'created_by', 'current_version_id', 'created_at', 'updated_at', 'deleted_at',
+        ]));
+    }
+
+    public function test_document_versions_table_exists(): void
+    {
+        $this->assertTrue(Schema::hasTable('rf_document_versions'));
+        $this->assertTrue(Schema::hasColumns('rf_document_versions', [
+            'id', 'document_template_id', 'version_number', 'body', 'file_path',
+            'merge_fields', 'published_at', 'created_by', 'created_at', 'updated_at',
+        ]));
+    }
+
+    public function test_document_records_table_exists_with_polymorphic_source(): void
+    {
+        $this->assertTrue(Schema::hasTable('rf_document_records'));
+        $this->assertTrue(Schema::hasColumns('rf_document_records', [
+            'id', 'account_tenant_id', 'document_template_version_id',
+            'source_type', 'source_id', 'generated_at', 'file_path', 'status',
+            'created_at', 'updated_at', 'deleted_at',
+        ]));
+    }
+
+    public function test_document_signatures_table_exists(): void
+    {
+        $this->assertTrue(Schema::hasTable('rf_document_signatures'));
+        $this->assertTrue(Schema::hasColumns('rf_document_signatures', [
+            'id', 'document_record_id', 'signer_name', 'signer_email',
+            'signed_at', 'ip_address', 'otp_verified_at', 'signed_file_path',
+            'created_at', 'updated_at',
+        ]));
+    }
+
+    public function test_document_template_has_localized_name_column(): void
+    {
+        $this->assertSame('json', Schema::getColumnType('rf_document_templates', 'name'));
+    }
+
+    public function test_document_version_merge_fields_is_json(): void
+    {
+        $this->assertSame('json', Schema::getColumnType('rf_document_versions', 'merge_fields'));
+    }
+}


### PR DESCRIPTION
Closes #199

## Summary
Core Documents data model consumed by Leasing, Facilities, Accounting, and Contacts for contract/invoice/KYC generation.

## Models Created
- **DocumentTemplate** — localized name (EN/AR JSON), type (lease/booking/invoice/receipt/custom), status (draft/active/archived), format (word_upload/in_platform), current version pointer
- **DocumentVersion** — captured template revision with version_number, body OR file_path, merge_fields JSON schema, publication timestamp
- **DocumentRecord** — generated document instance with polymorphic source (any domain), pinned to exact template version at generation time
- **DocumentSignature** — each signing event with signer identity, OTP verification, IP address, countersigned file path

## Design Decisions
- **Polymorphic source** on DocumentRecord (`source_type` + `source_id`) — aligns with platform convention, allows any domain to attach docs
- **Tenant isolation** via `BelongsToAccountTenant` trait (Spatie global scope)
- **JSON columns** for `name` (bilingual) and `merge_fields` (schema) — no separate locale/fields tables
- **Soft deletes** on templates and records (not versions or signatures)
- **Timestamped migrations** ensure correct FK dependency order

## Verification
- 4 tables created with correct columns and foreign keys
- 6 tests pass (schema verification)