### PR TITLE
feat(documents): Download original and signed documents from record

### DIFF
--- a/app/Http/Controllers/Admin/DocumentRecordController.php
+++ b/app/Http/Controllers/Admin/DocumentRecordController.php
@@ -10,6 +10,7 @@ use Illuminate\Http\Request;
 use Illuminate\Support\Str;
 use Inertia\Inertia;
 use Inertia\Response;
+use Symfony\Component\HttpFoundation\StreamedResponse;
 
 class DocumentRecordController extends Controller
 {
@@ -89,5 +90,35 @@ class DocumentRecordController extends Controller
         ]);
 
         return back()->with('success', __('Signing link resent.'));
+    }
+
+    public function download(DocumentRecord $documentRecord): StreamedResponse
+    {
+        $this->authorize('view', $documentRecord->templateVersion?->template);
+
+        $content = $documentRecord->file_path ?? '';
+
+        return response()->streamDownload(
+            fn () => print ($content),
+            "document-{$documentRecord->id}-{$documentRecord->source_type}.txt",
+            ['Content-Type' => 'text/plain']
+        );
+    }
+
+    public function downloadSigned(DocumentRecord $documentRecord): StreamedResponse
+    {
+        $this->authorize('view', $documentRecord->templateVersion?->template);
+
+        $signature = $documentRecord->signatures()->latest()->first();
+
+        if (! $signature || ! $signature->signed_file_path) {
+            abort(404, 'No signed version available.');
+        }
+
+        return response()->streamDownload(
+            fn () => print ($signature->signed_file_path),
+            "document-{$documentRecord->id}-signed.txt",
+            ['Content-Type' => 'text/plain']
+        );
     }
 }

--- a/routes/web.php
+++ b/routes/web.php
@@ -188,6 +188,8 @@ Route::middleware(['auth', 'verified', 'tenant'])->group(function () {
         Route::get('documents/records/{documentRecord}', [DocumentRecordController::class, 'show'])->name('documents.records.show');
         Route::post('documents/records/{documentRecord}/send', [DocumentRecordController::class, 'sendForSignature'])->name('documents.records.send');
         Route::post('documents/records/{documentRecord}/resend', [DocumentRecordController::class, 'resendLink'])->name('documents.records.resend');
+        Route::get('documents/records/{documentRecord}/download', [DocumentRecordController::class, 'download'])->name('documents.records.download');
+        Route::get('documents/records/{documentRecord}/download-signed', [DocumentRecordController::class, 'downloadSigned'])->name('documents.records.downloadSigned');
     });
 
     // Public signing (no auth)


### PR DESCRIPTION
Closes #204
## Summary
Download generated and signed documents from admin document record page.
- GET /admin/documents/records/{id}/download — serves generated document as text/plain
- GET /admin/documents/records/{id}/download-signed — serves signed document (404 if not signed)