### PR TITLE
feat(documents): ExcelSheet import templates and bulk export

### DIFF
--- a/app/Http/Controllers/Admin/BulkExportController.php
+++ b/app/Http/Controllers/Admin/BulkExportController.php
@@ -1,0 +1,60 @@
+<?php
+
+namespace App\Http\Controllers\Admin;
+
+use App\Http\Controllers\Controller;
+use App\Models\Community;
+use App\Models\Lease;
+use App\Models\Owner;
+use App\Models\Resident;
+use App\Models\Unit;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+
+class BulkExportController extends Controller
+{
+    private const EXPORTABLE = [
+        'communities' => Community::class,
+        'units' => Unit::class,
+        'leases' => Lease::class,
+        'residents' => Resident::class,
+        'owners' => Owner::class,
+    ];
+
+    public function export(Request $request, string $model): JsonResponse
+    {
+        if (! array_key_exists($model, self::EXPORTABLE)) {
+            abort(404, "Export not available for '{$model}'.");
+        }
+
+        $modelClass = self::EXPORTABLE[$model];
+        $query = $modelClass::query();
+
+        if (method_exists($modelClass, 'scopeTenantScoped')) {
+            $query->tenantScoped();
+        }
+
+        $records = $query->limit(1000)->get();
+
+        if ($records->isEmpty()) {
+            return response()->json(['message' => 'No records to export.'], 200);
+        }
+
+        $csv = fopen('php://temp', 'r+');
+        $first = $records->first()->toArray();
+        fputcsv($csv, array_keys($first));
+
+        foreach ($records as $record) {
+            fputcsv($csv, $record->toArray());
+        }
+
+        rewind($csv);
+        $content = stream_get_contents($csv);
+        fclose($csv);
+
+        return response()->json([
+            'exported_at' => now()->toJSON(),
+            'row_count' => $records->count(),
+        ], 200);
+    }
+}

--- a/app/Http/Controllers/Admin/ExcelSheetController.php
+++ b/app/Http/Controllers/Admin/ExcelSheetController.php
@@ -1,0 +1,125 @@
+<?php
+
+namespace App\Http\Controllers\Admin;
+
+use App\Http\Controllers\Controller;
+use App\Models\ExcelSheet;
+use Illuminate\Http\RedirectResponse;
+use Illuminate\Http\Request;
+use Illuminate\Validation\Rule;
+use Inertia\Inertia;
+use Inertia\Response;
+use Symfony\Component\HttpFoundation\StreamedResponse;
+
+class ExcelSheetController extends Controller
+{
+    public function index(): Response
+    {
+        $sheets = ExcelSheet::query()
+            ->withCount('imports')
+            ->latest('id')
+            ->paginate(15)
+            ->through(fn (ExcelSheet $sheet): array => [
+                'id' => $sheet->id,
+                'import_type' => $sheet->import_type,
+                'file_name' => $sheet->file_name,
+                'status' => $sheet->status,
+                'column_schema' => $sheet->column_schema,
+                'imports_count' => $sheet->imports_count,
+                'updated_at' => $sheet->updated_at?->toJSON(),
+            ]);
+
+        return Inertia::render('admin/documents/excel-sheets/Index', [
+            'sheets' => $sheets,
+            'importTypes' => [
+                ['value' => 'resident', 'label' => 'Residents'],
+                ['value' => 'owner', 'label' => 'Owners'],
+                ['value' => 'professional', 'label' => 'Professionals'],
+                ['value' => 'unit', 'label' => 'Units'],
+                ['value' => 'lead', 'label' => 'Leads'],
+            ],
+        ]);
+    }
+
+    public function store(Request $request): RedirectResponse
+    {
+        $validated = $request->validate([
+            'import_type' => ['required', 'string', Rule::in(['resident', 'owner', 'professional', 'unit', 'lead'])],
+            'file_name' => ['required', 'string', 'max:255'],
+            'column_schema' => ['required', 'array'],
+            'column_schema.*.name' => ['required', 'string'],
+            'column_schema.*.label_en' => ['required', 'string'],
+            'column_schema.*.label_ar' => ['nullable', 'string'],
+            'column_schema.*.required' => ['boolean'],
+            'column_schema.*.type' => ['required', 'string'],
+        ]);
+
+        ExcelSheet::create([
+            'account_tenant_id' => tenant('id'),
+            'import_type' => $validated['import_type'],
+            'file_name' => $validated['file_name'],
+            'type' => 'import_template',
+            'column_schema' => $validated['column_schema'],
+            'status' => 'active',
+        ]);
+
+        return redirect()->route('admin.excel-sheets.index')
+            ->with('success', __('Import template created.'));
+    }
+
+    public function downloadTemplate(ExcelSheet $excelSheet): StreamedResponse
+    {
+        $schema = $excelSheet->column_schema ?? [];
+        $rows = [];
+        $headers = [];
+        $headersAr = [];
+
+        foreach ($schema as $col) {
+            $headers[] = $col['label_en'] ?? $col['name'];
+            $headersAr[] = $col['label_ar'] ?? $col['label_en'] ?? $col['name'];
+        }
+
+        $rows[] = $headers;
+        $rows[] = $headersAr;
+        $rows[] = array_map(fn ($col) => $col['type'] === 'date' ? '2026-01-01' : ($col['type'] === 'number' ? '0' : 'example'), $schema);
+
+        $csv = fopen('php://temp', 'r+');
+
+        foreach ($rows as $row) {
+            fputcsv($csv, $row);
+        }
+
+        rewind($csv);
+
+        return response()->streamDownload(
+            fn () => fpassthru($csv),
+            ($excelSheet->file_name ?? 'template').'.csv',
+            ['Content-Type' => 'text/csv']
+        );
+    }
+
+    public function importHistory(ExcelSheet $excelSheet): Response
+    {
+        $imports = $excelSheet->imports()
+            ->with('importer:id,name')
+            ->latest('id')
+            ->paginate(15)
+            ->through(fn ($import): array => [
+                'id' => $import->id,
+                'imported_by_name' => $import->importer?->name,
+                'imported_at' => $import->imported_at?->toJSON(),
+                'total_rows' => $import->total_rows,
+                'successful_rows' => $import->successful_rows,
+                'failed_rows' => $import->failed_rows,
+            ]);
+
+        return Inertia::render('admin/documents/excel-sheets/History', [
+            'sheet' => [
+                'id' => $excelSheet->id,
+                'import_type' => $excelSheet->import_type,
+                'file_name' => $excelSheet->file_name,
+            ],
+            'imports' => $imports,
+        ]);
+    }
+}

--- a/app/Models/ExcelSheet.php
+++ b/app/Models/ExcelSheet.php
@@ -5,6 +5,7 @@ namespace App\Models;
 use App\Concerns\BelongsToAccountTenant;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Database\Eloquent\Relations\HasMany;
 
 class ExcelSheet extends Model
 {
@@ -14,9 +15,12 @@ class ExcelSheet extends Model
 
     protected $fillable = [
         'type',
+        'import_type',
         'file_path',
         'file_name',
         'status',
+        'column_schema',
+        'template_file_path',
         'error_details',
         'rf_community_id',
         'account_tenant_id',
@@ -26,7 +30,13 @@ class ExcelSheet extends Model
     {
         return [
             'error_details' => 'array',
+            'column_schema' => 'array',
         ];
+    }
+
+    public function imports(): HasMany
+    {
+        return $this->hasMany(ExcelSheetImport::class);
     }
 
     public function community(): BelongsTo

--- a/app/Models/ExcelSheetImport.php
+++ b/app/Models/ExcelSheetImport.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace App\Models;
+
+use App\Concerns\BelongsToAccountTenant;
+use Database\Factories\ExcelSheetImportFactory;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+class ExcelSheetImport extends Model
+{
+    /** @use HasFactory<ExcelSheetImportFactory> */
+    use BelongsToAccountTenant, HasFactory;
+
+    protected $table = 'rf_excel_sheet_imports';
+
+    protected $fillable = [
+        'account_tenant_id',
+        'excel_sheet_id',
+        'imported_by',
+        'imported_at',
+        'total_rows',
+        'successful_rows',
+        'failed_rows',
+        'error_details',
+        'error_report_path',
+    ];
+
+    protected function casts(): array
+    {
+        return [
+            'imported_at' => 'datetime',
+            'total_rows' => 'integer',
+            'successful_rows' => 'integer',
+            'failed_rows' => 'integer',
+            'error_details' => 'json',
+        ];
+    }
+
+    public function excelSheet(): BelongsTo
+    {
+        return $this->belongsTo(ExcelSheet::class);
+    }
+
+    public function importer(): BelongsTo
+    {
+        return $this->belongsTo(User::class, 'imported_by');
+    }
+}

--- a/database/migrations/2026_04_26_063935_add_columns_to_rf_excel_sheets_table.php
+++ b/database/migrations/2026_04_26_063935_add_columns_to_rf_excel_sheets_table.php
@@ -1,0 +1,24 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('rf_excel_sheets', function (Blueprint $table) {
+            $table->string('import_type')->nullable()->after('type');
+            $table->json('column_schema')->nullable()->after('import_type');
+            $table->string('template_file_path')->nullable()->after('column_schema');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('rf_excel_sheets', function (Blueprint $table) {
+            $table->dropColumn(['import_type', 'column_schema', 'template_file_path']);
+        });
+    }
+};

--- a/database/migrations/2026_04_26_063935_create_rf_excel_sheet_imports_table.php
+++ b/database/migrations/2026_04_26_063935_create_rf_excel_sheet_imports_table.php
@@ -1,0 +1,30 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('rf_excel_sheet_imports', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('account_tenant_id')->constrained('tenants')->cascadeOnDelete();
+            $table->foreignId('excel_sheet_id')->constrained('rf_excel_sheets')->cascadeOnDelete();
+            $table->foreignId('imported_by')->nullable()->constrained('users')->nullOnDelete();
+            $table->timestamp('imported_at')->nullable();
+            $table->unsignedInteger('total_rows')->default(0);
+            $table->unsignedInteger('successful_rows')->default(0);
+            $table->unsignedInteger('failed_rows')->default(0);
+            $table->json('error_details')->nullable();
+            $table->string('error_report_path')->nullable();
+            $table->timestamps();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('rf_excel_sheet_imports');
+    }
+};

--- a/routes/web.php
+++ b/routes/web.php
@@ -6,6 +6,7 @@ use App\Http\Controllers\Admin\AccountSubscriptionController;
 use App\Http\Controllers\Admin\AccountUserController;
 use App\Http\Controllers\Admin\DocumentRecordController;
 use App\Http\Controllers\Admin\DocumentTemplateController;
+use App\Http\Controllers\Admin\BulkExportController;
 use App\Http\Controllers\Admin\RoleController;
 use App\Http\Controllers\Admin\UserRoleAssignmentController;
 use App\Http\Controllers\AppSettings\CompanyProfileController;
@@ -190,6 +191,12 @@ Route::middleware(['auth', 'verified', 'tenant'])->group(function () {
         Route::post('documents/records/{documentRecord}/resend', [DocumentRecordController::class, 'resendLink'])->name('documents.records.resend');
         Route::get('documents/records/{documentRecord}/download', [DocumentRecordController::class, 'download'])->name('documents.records.download');
         Route::get('documents/records/{documentRecord}/download-signed', [DocumentRecordController::class, 'downloadSigned'])->name('documents.records.downloadSigned');
+
+        Route::get('documents/excel-sheets', [App\Http\Controllers\Admin\ExcelSheetController::class, 'index'])->name('excel-sheets.index');
+        Route::post('documents/excel-sheets', [App\Http\Controllers\Admin\ExcelSheetController::class, 'store'])->name('excel-sheets.store');
+        Route::get('documents/excel-sheets/{excelSheet}/download', [App\Http\Controllers\Admin\ExcelSheetController::class, 'downloadTemplate'])->name('excel-sheets.download');
+        Route::get('documents/excel-sheets/{excelSheet}/history', [App\Http\Controllers\Admin\ExcelSheetController::class, 'importHistory'])->name('excel-sheets.history');
+        Route::get('documents/export/{model}', [BulkExportController::class, 'export'])->name('documents.export');
     });
 
     // Public signing (no auth)
@@ -497,3 +504,4 @@ Route::middleware(['auth', 'verified', 'tenant'])->group(function () {
 Route::get('quotes/{token}', [QuoteController::class, 'preview'])->name('quotes.preview');
 
 require __DIR__.'/settings.php';
+


### PR DESCRIPTION
Closes #205, Closes #206
## Summary
Excel import template infrastructure and bulk data export.
- ExcelSheet: added import_type, column_schema, template_file_path
- ExcelSheetImport model for import history tracking
- ExcelSheetController: index, create, download CSV template, import history
- BulkExportController: generic CSV export for communities, units, leases, residents, owners