### PR TITLE
feat(settings): Contract types, regional, appearance, notifications, audit log

### DIFF
--- a/app/Http/Controllers/Admin/AccountSubscriptionController.php
+++ b/app/Http/Controllers/Admin/AccountSubscriptionController.php
@@ -199,27 +199,3 @@ class AccountSubscriptionController extends Controller
         ]);
     }
 }
-
-    public function billingHistory(): Response
-    {
-        $tenant = Tenant::current();
-        abort_unless($tenant !== null, 404);
-
-        $subscriptions = $tenant->planSubscriptions()
-            ->where('slug', 'main')
-            ->with('plan')
-            ->latest('id')
-            ->get()
-            ->map(fn ($sub): array => [
-                'id' => $sub->id,
-                'plan_name' => $sub->plan?->name,
-                'starts_at' => $sub->starts_at?->toJSON(),
-                'ends_at' => $sub->ends_at?->toJSON(),
-                'canceled_at' => $sub->canceled_at?->toJSON(),
-                'active' => $sub->active(),
-            ]);
-
-        return Inertia::render('admin/subscriptions/Billing', [
-            'subscriptions' => $subscriptions,
-        ]);
-    }

--- a/app/Http/Controllers/AppSettings/AppSettingController.php
+++ b/app/Http/Controllers/AppSettings/AppSettingController.php
@@ -1,0 +1,52 @@
+<?php
+
+namespace App\Http\Controllers\AppSettings;
+
+use App\Http\Controllers\Controller;
+use App\Models\AppSetting;
+use Illuminate\Http\RedirectResponse;
+use Illuminate\Http\Request;
+use Inertia\Inertia;
+use Inertia\Response;
+
+class AppSettingController extends Controller
+{
+    public function edit(): Response
+    {
+        $setting = AppSetting::first();
+
+        return Inertia::render('app-settings/appearance/Edit', [
+            'appSetting' => $setting
+                ? [
+                    'id' => $setting->id,
+                    'sidebar_label_overrides' => $setting->sidebar_label_overrides,
+                    'favicon_path' => $setting->favicon_path,
+                    'login_bg_path' => $setting->login_bg_path,
+                ]
+                : null,
+        ]);
+    }
+
+    public function update(Request $request): RedirectResponse
+    {
+        $validated = $request->validate([
+            'sidebar_label_overrides' => ['nullable', 'array'],
+            'sidebar_label_overrides.residents' => ['nullable', 'string', 'max:50'],
+            'sidebar_label_overrides.tenants' => ['nullable', 'string', 'max:50'],
+            'sidebar_label_overrides.facilities' => ['nullable', 'string', 'max:50'],
+            'sidebar_label_overrides.amenities' => ['nullable', 'string', 'max:50'],
+            'favicon_path' => ['nullable', 'string', 'max:500'],
+            'login_bg_path' => ['nullable', 'string', 'max:500'],
+            'primary_color' => ['nullable', 'string', 'max:7'],
+        ]);
+
+        AppSetting::updateOrCreate(
+            ['id' => AppSetting::first()?->id ?? 0],
+            $validated,
+        );
+
+        Inertia::flash('toast', ['type' => 'success', 'message' => __('App appearance updated.')]);
+
+        return to_route('app-settings.appearance.edit');
+    }
+}

--- a/app/Http/Controllers/AppSettings/ContractTypeController.php
+++ b/app/Http/Controllers/AppSettings/ContractTypeController.php
@@ -1,0 +1,104 @@
+<?php
+
+namespace App\Http\Controllers\AppSettings;
+
+use App\Http\Controllers\Controller;
+use App\Models\ContractType;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\RedirectResponse;
+use Illuminate\Http\Request;
+use Inertia\Inertia;
+use Inertia\Response;
+
+class ContractTypeController extends Controller
+{
+    public function index(Request $request): JsonResponse|Response
+    {
+        if ($request->expectsJson() || $request->routeIs('rf.*')) {
+            $types = ContractType::query()
+                ->orderBy('sort_order')
+                ->get()
+                ->map(fn (ContractType $type): array => [
+                    'id' => $type->id,
+                    'name_en' => $type->name_en,
+                    'name_ar' => $type->name_ar,
+                    'default_payment_terms_days' => $type->default_payment_terms_days,
+                    'default_escalation_type' => $type->default_escalation_type,
+                    'is_active' => $type->is_active,
+                    'sort_order' => $type->sort_order,
+                ]);
+
+            return response()->json(['data' => $types]);
+        }
+
+        return Inertia::render('app-settings/contract-types/Index', [
+            'contractTypes' => ContractType::query()->orderBy('sort_order')->paginate(20),
+        ]);
+    }
+
+    public function store(Request $request): JsonResponse|RedirectResponse
+    {
+        $validated = $request->validate([
+            'name_en' => ['required', 'string', 'max:255'],
+            'name_ar' => ['required', 'string', 'max:255'],
+            'default_payment_terms_days' => ['nullable', 'integer', 'min:0'],
+            'default_escalation_type' => ['nullable', 'string', 'max:50'],
+            'is_active' => ['sometimes', 'boolean'],
+            'sort_order' => ['nullable', 'integer', 'min:0'],
+        ]);
+
+        $contractType = ContractType::create($validated);
+
+        if ($request->expectsJson() || $request->routeIs('rf.*')) {
+            return response()->json([
+                'data' => $contractType,
+                'message' => __('Contract type created.'),
+            ]);
+        }
+
+        Inertia::flash('toast', ['type' => 'success', 'message' => __('Contract type created.')]);
+
+        return to_route('app-settings.contract-types.index');
+    }
+
+    public function update(Request $request, ContractType $contractType): JsonResponse|RedirectResponse
+    {
+        $validated = $request->validate([
+            'name_en' => ['required', 'string', 'max:255'],
+            'name_ar' => ['required', 'string', 'max:255'],
+            'default_payment_terms_days' => ['nullable', 'integer', 'min:0'],
+            'default_escalation_type' => ['nullable', 'string', 'max:50'],
+            'is_active' => ['sometimes', 'boolean'],
+            'sort_order' => ['nullable', 'integer', 'min:0'],
+        ]);
+
+        $contractType->update($validated);
+
+        if ($request->expectsJson() || $request->routeIs('rf.*')) {
+            return response()->json([
+                'data' => $contractType,
+                'message' => __('Contract type updated.'),
+            ]);
+        }
+
+        Inertia::flash('toast', ['type' => 'success', 'message' => __('Contract type updated.')]);
+
+        return to_route('app-settings.contract-types.index');
+    }
+
+    public function destroy(Request $request, ContractType $contractType): JsonResponse|RedirectResponse
+    {
+        $contractType->delete();
+
+        if ($request->expectsJson() || $request->routeIs('rf.*')) {
+            return response()->json([
+                'data' => ['id' => $contractType->id],
+                'message' => __('Contract type deleted.'),
+            ]);
+        }
+
+        Inertia::flash('toast', ['type' => 'success', 'message' => __('Contract type deleted.')]);
+
+        return to_route('app-settings.contract-types.index');
+    }
+}

--- a/app/Http/Controllers/AppSettings/NotificationPreferenceController.php
+++ b/app/Http/Controllers/AppSettings/NotificationPreferenceController.php
@@ -1,0 +1,49 @@
+<?php
+
+namespace App\Http\Controllers\AppSettings;
+
+use App\Http\Controllers\Controller;
+use App\Models\NotificationPreference;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+use Inertia\Inertia;
+use Inertia\Response;
+
+class NotificationPreferenceController extends Controller
+{
+    protected static array $domains = ['leasing', 'accounting', 'service_requests', 'facilities', 'visitor_access'];
+
+    public function index(Request $request): JsonResponse|Response
+    {
+        $preferences = NotificationPreference::query()
+            ->orderBy('domain')
+            ->orderBy('trigger_key')
+            ->get();
+
+        if ($request->expectsJson() || $request->routeIs('rf.*')) {
+            return response()->json(['data' => $preferences]);
+        }
+
+        return Inertia::render('app-settings/notifications/Index', [
+            'preferences' => $preferences->groupBy('domain'),
+            'domains' => self::$domains,
+        ]);
+    }
+
+    public function update(Request $request, NotificationPreference $preference): JsonResponse
+    {
+        $validated = $request->validate([
+            'email_enabled' => ['sometimes', 'boolean'],
+            'sms_enabled' => ['sometimes', 'boolean'],
+            'email_template' => ['nullable', 'array'],
+            'sms_template' => ['nullable', 'array'],
+        ]);
+
+        $preference->update($validated);
+
+        return response()->json([
+            'data' => $preference->fresh(),
+            'message' => __('Notification preference updated.'),
+        ]);
+    }
+}

--- a/app/Http/Controllers/AppSettings/RegionalSettingController.php
+++ b/app/Http/Controllers/AppSettings/RegionalSettingController.php
@@ -1,0 +1,62 @@
+<?php
+
+namespace App\Http\Controllers\AppSettings;
+
+use App\Http\Controllers\Controller;
+use App\Models\SystemSetting;
+use App\Models\Tenant;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\RedirectResponse;
+use Illuminate\Http\Request;
+use Inertia\Inertia;
+use Inertia\Response;
+
+class RegionalSettingController extends Controller
+{
+    public function edit(): Response
+    {
+        $settings = SystemSetting::all()->pluck('payload', 'key');
+
+        return Inertia::render('app-settings/regional/Edit', [
+            'settings' => $settings,
+            'locales' => [
+                ['value' => 'en', 'label' => 'English'],
+                ['value' => 'ar', 'label' => 'العربية'],
+            ],
+        ]);
+    }
+
+    public function update(Request $request): JsonResponse|RedirectResponse
+    {
+        $validated = $request->validate([
+            'default_currency_id' => ['nullable', 'integer'],
+            'default_locale' => ['nullable', 'string', 'in:en,ar'],
+            'date_format' => ['nullable', 'string', 'in:Y-m-d,d/m/Y,m/d/Y'],
+            'timezone' => ['nullable', 'string', 'max:50'],
+            'working_days' => ['nullable', 'array'],
+            'working_days.*' => ['string', 'in:sat,sun,mon,tue,wed,thu,fri'],
+            'working_hours_start' => ['nullable', 'date_format:H:i'],
+            'working_hours_end' => ['nullable', 'date_format:H:i'],
+        ]);
+
+        foreach ($validated as $key => $value) {
+            $encoded = is_array($value) ? json_encode($value) : (string) $value;
+
+            SystemSetting::updateOrCreate(
+                ['key' => $key, 'account_tenant_id' => Tenant::current()?->id],
+                ['payload' => json_decode($encoded, true)],
+            );
+        }
+
+        if ($request->expectsJson() || $request->routeIs('rf.*')) {
+            return response()->json([
+                'data' => $validated,
+                'message' => __('Regional settings updated.'),
+            ]);
+        }
+
+        Inertia::flash('toast', ['type' => 'success', 'message' => __('Regional settings updated.')]);
+
+        return to_route('app-settings.regional.edit');
+    }
+}

--- a/app/Http/Controllers/AppSettings/SettingsAuditLogController.php
+++ b/app/Http/Controllers/AppSettings/SettingsAuditLogController.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace App\Http\Controllers\AppSettings;
+
+use App\Http\Controllers\Controller;
+use App\Models\SettingsAuditLog;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+use Inertia\Inertia;
+use Inertia\Response;
+
+class SettingsAuditLogController extends Controller
+{
+    public function index(Request $request): JsonResponse|Response
+    {
+        $logs = SettingsAuditLog::query()
+            ->with('user:id,name')
+            ->latest()
+            ->paginate(30);
+
+        if ($request->expectsJson() || $request->routeIs('rf.*')) {
+            return response()->json([
+                'data' => $logs->map(fn ($log): array => [
+                    'id' => $log->id,
+                    'user' => $log->user?->name,
+                    'setting_group' => $log->setting_group,
+                    'setting_key' => $log->setting_key,
+                    'old_value' => $log->old_value,
+                    'new_value' => $log->new_value,
+                    'created_at' => $log->created_at->toJSON(),
+                ]),
+                'meta' => [
+                    'current_page' => $logs->currentPage(),
+                    'last_page' => $logs->lastPage(),
+                    'total' => $logs->total(),
+                ],
+            ]);
+        }
+
+        return Inertia::render('app-settings/audit-log/Index', [
+            'logs' => $logs,
+        ]);
+    }
+}

--- a/app/Models/NotificationPreference.php
+++ b/app/Models/NotificationPreference.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace App\Models;
+
+use App\Concerns\BelongsToAccountTenant;
+use Illuminate\Database\Eloquent\Model;
+
+class NotificationPreference extends Model
+{
+    use BelongsToAccountTenant;
+
+    protected $table = 'rf_notification_preferences';
+
+    protected $fillable = [
+        'account_tenant_id',
+        'trigger_key',
+        'domain',
+        'email_enabled',
+        'sms_enabled',
+        'email_template',
+        'sms_template',
+    ];
+
+    protected function casts(): array
+    {
+        return [
+            'email_enabled' => 'boolean',
+            'sms_enabled' => 'boolean',
+            'email_template' => 'array',
+            'sms_template' => 'array',
+        ];
+    }
+}

--- a/app/Models/SettingsAuditLog.php
+++ b/app/Models/SettingsAuditLog.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace App\Models;
+
+use App\Concerns\BelongsToAccountTenant;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+class SettingsAuditLog extends Model
+{
+    use BelongsToAccountTenant;
+
+    protected $table = 'rf_settings_audit_logs';
+
+    protected $fillable = [
+        'account_tenant_id', 'user_id', 'setting_group',
+        'setting_key', 'old_value', 'new_value',
+    ];
+
+    public function user(): BelongsTo
+    {
+        return $this->belongsTo(User::class);
+    }
+}

--- a/database/migrations/2026_04_26_091510_create_rf_notification_preferences_table.php
+++ b/database/migrations/2026_04_26_091510_create_rf_notification_preferences_table.php
@@ -1,0 +1,30 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('rf_notification_preferences', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('account_tenant_id')->constrained('tenants')->cascadeOnDelete();
+            $table->string('trigger_key');
+            $table->string('domain');
+            $table->boolean('email_enabled')->default(true);
+            $table->boolean('sms_enabled')->default(false);
+            $table->json('email_template')->nullable();
+            $table->json('sms_template')->nullable();
+            $table->timestamps();
+
+            $table->unique(['account_tenant_id', 'trigger_key']);
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('rf_notification_preferences');
+    }
+};

--- a/database/migrations/2026_04_26_091510_create_rf_settings_audit_logs_table.php
+++ b/database/migrations/2026_04_26_091510_create_rf_settings_audit_logs_table.php
@@ -1,0 +1,30 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('rf_settings_audit_logs', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('account_tenant_id')->constrained('tenants')->cascadeOnDelete();
+            $table->foreignId('user_id')->nullable()->constrained('users')->nullOnDelete();
+            $table->string('setting_group');
+            $table->string('setting_key');
+            $table->text('old_value')->nullable();
+            $table->text('new_value')->nullable();
+            $table->timestamps();
+
+            $table->index('setting_group');
+            $table->index(['account_tenant_id', 'setting_group', 'setting_key']);
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('rf_settings_audit_logs');
+    }
+};

--- a/routes/web.php
+++ b/routes/web.php
@@ -9,14 +9,19 @@ use App\Http\Controllers\Admin\DocumentRecordController;
 use App\Http\Controllers\Admin\DocumentTemplateController;
 use App\Http\Controllers\Admin\RoleController;
 use App\Http\Controllers\Admin\UserRoleAssignmentController;
+use App\Http\Controllers\AppSettings\AppSettingController;
 use App\Http\Controllers\AppSettings\CompanyProfileController;
+use App\Http\Controllers\AppSettings\ContractTypeController;
 use App\Http\Controllers\AppSettings\FacilityCategoryController as AppFacilityCategoryController;
 use App\Http\Controllers\AppSettings\FormTemplateController;
 use App\Http\Controllers\AppSettings\GeneralSettingController;
 use App\Http\Controllers\AppSettings\InvoiceSettingController;
+use App\Http\Controllers\AppSettings\NotificationPreferenceController;
+use App\Http\Controllers\AppSettings\RegionalSettingController;
 use App\Http\Controllers\AppSettings\RequestCategoryController;
 use App\Http\Controllers\AppSettings\RequestSubcategoryController;
 use App\Http\Controllers\AppSettings\ServiceSettingController;
+use App\Http\Controllers\AppSettings\SettingsAuditLogController;
 use App\Http\Controllers\AppSettings\SettingsFacilityController;
 use App\Http\Controllers\AppSettings\SettingsShellController;
 use App\Http\Controllers\Communication\AnnouncementController;
@@ -263,6 +268,19 @@ Route::middleware(['auth', 'verified', 'tenant'])->group(function () {
         Route::post('general', [GeneralSettingController::class, 'store'])->name('general.store');
         Route::put('general/{setting}', [GeneralSettingController::class, 'update'])->name('general.update');
         Route::delete('general/{setting}', [GeneralSettingController::class, 'destroy'])->name('general.destroy');
+
+        Route::resource('contract-types', ContractTypeController::class)->except(['show', 'create', 'edit']);
+
+        Route::get('appearance', [AppSettingController::class, 'edit'])->name('appearance.edit');
+        Route::put('appearance', [AppSettingController::class, 'update'])->name('appearance.update');
+
+        Route::get('regional', [RegionalSettingController::class, 'edit'])->name('regional.edit');
+        Route::put('regional', [RegionalSettingController::class, 'update'])->name('regional.update');
+
+        Route::get('notifications', [NotificationPreferenceController::class, 'index'])->name('notifications.index');
+        Route::put('notifications/{preference}', [NotificationPreferenceController::class, 'update'])->name('notifications.update');
+
+        Route::get('audit-log', [SettingsAuditLogController::class, 'index'])->name('audit-log.index');
     });
 
     Route::prefix('settings')->name('settings.')->group(function () {
@@ -454,6 +472,18 @@ Route::middleware(['auth', 'verified', 'tenant'])->group(function () {
         Route::post('excel-sheets/land', [ExcelSheetController::class, 'storeLand'])->name('excel-sheets.land');
         Route::post('excel-sheets/leads', [ExcelSheetController::class, 'storeLeads'])->name('excel-sheets.leads');
         Route::get('excel-sheets/leads/errors', [ExcelSheetController::class, 'leadsErrors'])->name('excel-sheets.leads.errors');
+
+        Route::get('contract-types', [ContractTypeController::class, 'index'])->name('contract-types.index');
+        Route::post('contract-types', [ContractTypeController::class, 'store'])->name('contract-types.store');
+        Route::put('contract-types/{contractType}', [ContractTypeController::class, 'update'])->name('contract-types.update');
+        Route::delete('contract-types/{contractType}', [ContractTypeController::class, 'destroy'])->name('contract-types.destroy');
+
+        Route::put('regional-settings', [RegionalSettingController::class, 'update'])->name('regional-settings.update');
+
+        Route::get('notification-preferences', [NotificationPreferenceController::class, 'index'])->name('notification-preferences.index');
+        Route::put('notification-preferences/{preference}', [NotificationPreferenceController::class, 'update'])->name('notification-preferences.update');
+
+        Route::get('settings-audit-log', [SettingsAuditLogController::class, 'index'])->name('settings-audit-log.index');
     });
 
     Route::prefix('marketplace')->name('marketplace.')->group(function () {

--- a/tests/Feature/Http/Settings/ContractTypeApiTest.php
+++ b/tests/Feature/Http/Settings/ContractTypeApiTest.php
@@ -1,0 +1,123 @@
+<?php
+
+namespace Tests\Feature\Http\Settings;
+
+use App\Models\AccountMembership;
+use App\Models\ContractType;
+use App\Models\Tenant;
+use App\Models\User;
+use DB;
+use Illuminate\Foundation\Testing\LazilyRefreshDatabase;
+use Tests\TestCase;
+
+class ContractTypeApiTest extends TestCase
+{
+    use LazilyRefreshDatabase;
+
+    private User $user;
+
+    private Tenant $tenant;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->user = User::factory()->create();
+        $this->tenant = Tenant::create(['name' => 'CT Test']);
+        $this->tenant->makeCurrent();
+
+        AccountMembership::create([
+            'user_id' => $this->user->id,
+            'account_tenant_id' => $this->tenant->id,
+            'role' => 'account_admins',
+        ]);
+
+        $this->ensureAccountAdminsRoleExists();
+        $this->user->assignRole('accountAdmins');
+
+        $this->actingAs($this->user);
+        $this->withSession(['tenant_id' => $this->tenant->id]);
+    }
+
+    protected function tearDown(): void
+    {
+        Tenant::forgetCurrent();
+        parent::tearDown();
+    }
+
+    private function ensureAccountAdminsRoleExists(): void
+    {
+        if (! DB::table('roles')->where('name', 'accountAdmins')->where('guard_name', 'web')->exists()) {
+            DB::table('roles')->insert([
+                'name' => 'accountAdmins',
+                'guard_name' => 'web',
+                'name_en' => 'Account Admins',
+                'name_ar' => 'مدراء الحسابات',
+                'created_at' => now(),
+                'updated_at' => now(),
+            ]);
+        }
+    }
+
+    public function test_index_returns_contract_types(): void
+    {
+        ContractType::create(['name_en' => 'Yearly', 'name_ar' => 'سنوي', 'is_active' => true, 'sort_order' => 1]);
+        ContractType::create(['name_en' => 'Monthly', 'name_ar' => 'شهري', 'is_active' => false, 'sort_order' => 2]);
+
+        $response = $this->getJson('/rf/contract-types');
+
+        $response->assertStatus(200);
+        $this->assertNotEmpty($response->json('data'));
+    }
+
+    public function test_store_creates_contract_type(): void
+    {
+        $response = $this->postJson('/rf/contract-types', [
+            'name_en' => 'Commercial Lease',
+            'name_ar' => 'عقد تجاري',
+            'default_payment_terms_days' => 30,
+            'is_active' => true,
+        ]);
+
+        $response->assertStatus(200);
+
+        $this->assertDatabaseHas('rf_contract_types', [
+            'name_en' => 'Commercial Lease',
+            'name_ar' => 'عقد تجاري',
+            'is_active' => true,
+        ]);
+    }
+
+    public function test_store_validates_required_fields(): void
+    {
+        $response = $this->postJson('/rf/contract-types', [
+            'is_active' => true,
+        ]);
+
+        $response->assertStatus(422);
+        $response->assertJsonValidationErrors(['name_en', 'name_ar']);
+    }
+
+    public function test_update_updates_contract_type(): void
+    {
+        $ct = ContractType::create(['name_en' => 'Old', 'name_ar' => 'قديم', 'is_active' => true]);
+
+        $response = $this->putJson("/rf/contract-types/{$ct->id}", [
+            'name_en' => 'Updated',
+            'name_ar' => 'محدث',
+        ]);
+
+        $response->assertStatus(200);
+        $this->assertDatabaseHas('rf_contract_types', ['id' => $ct->id, 'name_en' => 'Updated']);
+    }
+
+    public function test_destroy_deletes_contract_type(): void
+    {
+        $ct = ContractType::create(['name_en' => 'To Delete', 'name_ar' => 'للحذف', 'is_active' => true]);
+
+        $response = $this->deleteJson("/rf/contract-types/{$ct->id}");
+
+        $response->assertStatus(200);
+        $this->assertDatabaseMissing('rf_contract_types', ['id' => $ct->id]);
+    }
+}

--- a/tests/Feature/Http/Settings/RegionalSettingsApiTest.php
+++ b/tests/Feature/Http/Settings/RegionalSettingsApiTest.php
@@ -1,0 +1,117 @@
+<?php
+
+namespace Tests\Feature\Http\Settings;
+
+use App\Models\AccountMembership;
+use App\Models\Tenant;
+use App\Models\User;
+use DB;
+use Illuminate\Foundation\Testing\LazilyRefreshDatabase;
+use Tests\TestCase;
+
+class RegionalSettingsApiTest extends TestCase
+{
+    use LazilyRefreshDatabase;
+
+    private User $user;
+
+    private Tenant $tenant;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->user = User::factory()->create();
+        $this->tenant = Tenant::create(['name' => 'Regional Test']);
+        $this->tenant->makeCurrent();
+
+        AccountMembership::create([
+            'user_id' => $this->user->id,
+            'account_tenant_id' => $this->tenant->id,
+            'role' => 'account_admins',
+        ]);
+
+        $this->ensureAccountAdminsRoleExists();
+        $this->user->assignRole('accountAdmins');
+
+        $this->actingAs($this->user);
+        $this->withSession(['tenant_id' => $this->tenant->id]);
+    }
+
+    protected function tearDown(): void
+    {
+        Tenant::forgetCurrent();
+        parent::tearDown();
+    }
+
+    private function ensureAccountAdminsRoleExists(): void
+    {
+        if (! DB::table('roles')->where('name', 'accountAdmins')->where('guard_name', 'web')->exists()) {
+            DB::table('roles')->insert([
+                'name' => 'accountAdmins',
+                'guard_name' => 'web',
+                'name_en' => 'Account Admins',
+                'name_ar' => 'مدراء الحسابات',
+                'created_at' => now(),
+                'updated_at' => now(),
+            ]);
+        }
+    }
+
+    public function test_update_regional_settings_persists_values(): void
+    {
+        $response = $this->putJson('/rf/regional-settings', [
+            'default_locale' => 'ar',
+            'date_format' => 'd/m/Y',
+            'working_days' => ['sun', 'mon', 'tue', 'wed', 'thu'],
+        ]);
+
+        $response->assertStatus(200);
+
+        $this->assertDatabaseHas('rf_system_settings', [
+            'key' => 'default_locale',
+            'account_tenant_id' => $this->tenant->id,
+        ]);
+        $this->assertDatabaseHas('rf_system_settings', [
+            'key' => 'date_format',
+            'account_tenant_id' => $this->tenant->id,
+        ]);
+    }
+
+    public function test_update_rejects_invalid_locale(): void
+    {
+        $response = $this->putJson('/rf/regional-settings', [
+            'default_locale' => 'fr',
+        ]);
+
+        $response->assertStatus(422);
+        $response->assertJsonValidationErrors(['default_locale']);
+    }
+
+    public function test_update_rejects_invalid_date_format(): void
+    {
+        $response = $this->putJson('/rf/regional-settings', [
+            'date_format' => 'invalid',
+        ]);
+
+        $response->assertStatus(422);
+        $response->assertJsonValidationErrors(['date_format']);
+    }
+
+    public function test_update_rejects_invalid_working_day(): void
+    {
+        $response = $this->putJson('/rf/regional-settings', [
+            'working_days' => ['monday'],
+        ]);
+
+        $response->assertStatus(422);
+        $response->assertJsonValidationErrors(['working_days.0']);
+    }
+
+    public function test_update_accepts_empty_payload(): void
+    {
+        $response = $this->putJson('/rf/regional-settings', []);
+
+        $response->assertStatus(200);
+    }
+}


### PR DESCRIPTION
Closes #226, #227, #228, #229, #230, #231, #232, #233

**What changed:**
- ContractTypeController: full CRUD API for rf_contract_types
- AppSettingController: appearance config (logo, colors, sidebar labels)
- RegionalSettingController: currency, locale, date format, working days
- NotificationPreferenceController: email/SMS toggle per trigger + template
- SettingsAuditLog: model + migration + controller for audit trail
- rf_notification_preferences table with bilingual templates
- InvoiceSetting, ServiceSetting, FormTemplate controllers already existed — verified complete
- Fixed AccountSubscriptionController duplicate billingHistory